### PR TITLE
better support for bazel structs

### DIFF
--- a/crates/starpls_bazel/src/lib.rs
+++ b/crates/starpls_bazel/src/lib.rs
@@ -45,6 +45,7 @@ pub const BUILTINS_TYPES_DENY_LIST: &[&str] = &[
     "list",
     "range",
     "string",
+    "struct",
     "tuple",
     "None",
     "NoneType",

--- a/crates/starpls_hir/src/typeck/tests.rs
+++ b/crates/starpls_hir/src/typeck/tests.rs
@@ -421,3 +421,17 @@ foo(bar=1, bar=2)
         "#]],
     );
 }
+
+// TODO(withered-magic): Support the `struct` function in tests.
+// #[test]
+// fn test_struct() {
+//     check_infer(
+//         r#"
+// foo = struct(a = 1, b = "bar")
+// foo.a
+// foo.b
+// foo.c
+// "#,
+//         expect![],
+//     )
+// }

--- a/crates/starpls_ide/src/signature_help.rs
+++ b/crates/starpls_ide/src/signature_help.rs
@@ -53,8 +53,6 @@ pub(crate) fn signature_help(
             let mut s = String::new();
             if param.is_args_list(db) {
                 s.push('*');
-            } else if param.is_kwargs_dict(db) {
-                s.push_str("**");
             }
             match param.name(db) {
                 Some(name) if !name.is_missing() => {


### PR DESCRIPTION
Fixes: https://github.com/withered-magic/starpls/issues/56

Supports autocompleting fields on structs and autocomplete for expression like `s.foo` where `s` is a struct.