### PR TITLE
native support for Bazel providers

### DIFF
--- a/crates/starpls_hir/src/api.rs
+++ b/crates/starpls_hir/src/api.rs
@@ -283,7 +283,7 @@ impl Type {
             TyKind::Function(func) => return func.doc(db).map(|doc| doc.to_string()),
             TyKind::IntrinsicFunction(func, _) => func.doc(db).clone(),
             TyKind::Rule(rule) => return rule.doc.as_ref().map(Box::to_string),
-            TyKind::Provider(provider) => return provider.doc.as_ref().map(Box::to_string),
+            TyKind::Provider(provider) => return provider.doc.map(|doc| doc.value(db).to_string()),
             _ => return None,
         })
     }

--- a/crates/starpls_hir/src/api.rs
+++ b/crates/starpls_hir/src/api.rs
@@ -258,7 +258,7 @@ impl Type {
     }
 
     pub fn is_callable(&self) -> bool {
-        self.is_function() || matches!(self.ty.kind(), TyKind::Rule(_))
+        self.is_function() || matches!(self.ty.kind(), TyKind::Rule(_) | TyKind::Provider(_))
     }
 
     pub fn is_unknown(&self) -> bool {
@@ -283,6 +283,7 @@ impl Type {
             TyKind::Function(func) => return func.doc(db).map(|doc| doc.to_string()),
             TyKind::IntrinsicFunction(func, _) => func.doc(db).clone(),
             TyKind::Rule(rule) => return rule.doc.as_ref().map(Box::to_string),
+            TyKind::Provider(provider) => return provider.doc.as_ref().map(Box::to_string),
             _ => return None,
         })
     }

--- a/crates/starpls_hir/src/display.rs
+++ b/crates/starpls_hir/src/display.rs
@@ -282,6 +282,7 @@ impl DisplayWithDb for TyKind {
             TyKind::ProviderInstance(provider) => {
                 provider.name.as_ref().map_or("_", |name| name.as_str())
             }
+            TyKind::ProviderRawConstructor(_, _) => "ProviderRawConstructor",
         };
 
         f.write_str(text)

--- a/crates/starpls_hir/src/display.rs
+++ b/crates/starpls_hir/src/display.rs
@@ -92,7 +92,8 @@ impl DisplayWithDb for TyKind {
                 return f.write_char(']');
             }
             TyKind::Bool(None) => "bool",
-            TyKind::Int => "int",
+            TyKind::Int(Some(x)) => return write!(f, "Literal[{}]", x),
+            TyKind::Int(None) => "int",
             TyKind::Float => "float",
             TyKind::String(Some(s)) => return write!(f, "Literal[{:?}]", s.value(db)),
             TyKind::String(None) => "string",

--- a/crates/starpls_hir/src/display.rs
+++ b/crates/starpls_hir/src/display.rs
@@ -272,6 +272,8 @@ impl DisplayWithDb for TyKind {
                 RuleKind::Build => "rule",
                 RuleKind::Repository => "repository_rule",
             },
+            TyKind::Provider(_) => "Provider",
+            TyKind::ProviderInstance(_) => "_",
         };
 
         f.write_str(text)

--- a/crates/starpls_hir/src/display.rs
+++ b/crates/starpls_hir/src/display.rs
@@ -273,7 +273,9 @@ impl DisplayWithDb for TyKind {
                 RuleKind::Repository => "repository_rule",
             },
             TyKind::Provider(_) => "Provider",
-            TyKind::ProviderInstance(_) => "_",
+            TyKind::ProviderInstance(provider) => {
+                provider.name.as_ref().map_or("_", |name| name.as_str())
+            }
         };
 
         f.write_str(text)

--- a/crates/starpls_hir/src/display.rs
+++ b/crates/starpls_hir/src/display.rs
@@ -272,7 +272,13 @@ impl DisplayWithDb for TyKind {
                 RuleKind::Build => "rule",
                 RuleKind::Repository => "repository_rule",
             },
-            TyKind::Provider(_) => "Provider",
+            TyKind::Provider(provider) => {
+                return write!(
+                    f,
+                    "Provider[{}]",
+                    provider.name.as_ref().map_or("_", |name| name.as_str())
+                );
+            }
             TyKind::ProviderInstance(provider) => {
                 provider.name.as_ref().map_or("_", |name| name.as_str())
             }

--- a/crates/starpls_hir/src/typeck.rs
+++ b/crates/starpls_hir/src/typeck.rs
@@ -440,7 +440,7 @@ impl Ty {
     }
 
     pub(crate) fn int() -> Ty {
-        TyKind::Int.intern()
+        TyKind::Int(None).intern()
     }
 
     pub(crate) fn string() -> Ty {
@@ -565,6 +565,7 @@ impl Ty {
     fn normalize(self) -> Ty {
         match self.kind() {
             TyKind::Bool(_) => Ty::bool(),
+            TyKind::Int(_) => Ty::int(),
             TyKind::String(_) => Ty::string(),
             _ => self,
         }
@@ -910,7 +911,7 @@ pub(crate) enum TyKind {
     /// A boolean.
     Bool(Option<bool>),
     /// A 64-bit integer.
-    Int,
+    Int(Option<i64>),
     /// A 64-bit floating point number.
     Float,
     /// A UTF-8 encoded string.
@@ -1374,7 +1375,8 @@ pub(crate) fn assign_tys(db: &dyn Db, source: &Ty, target: &Ty) -> bool {
         (TyKind::String(_), TyKind::String(_))
         | (TyKind::Attribute(_), TyKind::Attribute(_))
         | (TyKind::Struct(_), TyKind::Struct(_))
-        | (TyKind::Bool(_), TyKind::Bool(_)) => true,
+        | (TyKind::Bool(_), TyKind::Bool(_))
+        | (TyKind::Int(_), TyKind::Int(_)) => true,
         (source, target) => source == target,
     }
 }

--- a/crates/starpls_hir/src/typeck.rs
+++ b/crates/starpls_hir/src/typeck.rs
@@ -884,29 +884,12 @@ pub(crate) enum TyKind {
     Rule(Rule),
     /// A Bazel provider (https://bazel.build/rules/lib/builtins/Provider.html).
     /// This is a callable the yields "provider instances".
-    Provider(Provider),
+    Provider(Arc<Provider>),
     /// An instance of a provider. The contained `Ty` must have kind `TyKind::Provider`.
-    ProviderInstance(Ty),
+    ProviderInstance(Arc<Provider>),
 }
 
 impl_internable!(TyKind);
-
-impl TyKind {
-    pub fn intern(self) -> Ty {
-        Ty(Interned::new(self))
-    }
-
-    pub fn builtin_class(&self, db: &dyn Db) -> Option<IntrinsicClass> {
-        let intrinsics = intrinsic_types(db);
-        Some(match self {
-            TyKind::String => intrinsics.string_base_class(db),
-            TyKind::Bytes => intrinsics.bytes_base_class(db),
-            TyKind::List(_) => intrinsics.list_base_class(db),
-            TyKind::Dict(_, _, _) => intrinsics.dict_base_class(db),
-            _ => return None,
-        })
-    }
-}
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Tuple {
@@ -1008,7 +991,8 @@ impl Rule {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub(crate) struct Provider {
-    pub(crate) doc: Option<Box<str>>,
+    pub(crate) name: Option<Name>,
+    pub(crate) doc: Option<LiteralString>,
     pub(crate) fields: Option<Box<[ProviderField]>>,
 }
 

--- a/crates/starpls_hir/src/typeck.rs
+++ b/crates/starpls_hir/src/typeck.rs
@@ -393,7 +393,7 @@ impl Ty {
                         ))),
                 )
             }
-            TyKind::Provider(provider) => {
+            TyKind::Provider(provider) | TyKind::ProviderRawConstructor(_, provider) => {
                 Params::Provider(provider.fields.iter().flat_map(|fields| {
                     fields.iter().enumerate().map(|(index, _)| {
                         (
@@ -416,7 +416,9 @@ impl Ty {
             TyKind::IntrinsicFunction(func, subst) => func.ret_ty(db).substitute(&subst.args),
             TyKind::BuiltinFunction(func) => resolve_type_ref(db, &func.ret_type_ref(db)).0,
             TyKind::Rule(_) => Ty::none(),
-            TyKind::Provider(provider) => TyKind::ProviderInstance(provider.clone()).intern(),
+            TyKind::Provider(provider) | TyKind::ProviderRawConstructor(_, provider) => {
+                TyKind::ProviderInstance(provider.clone()).intern()
+            }
             _ => return None,
         })
     }
@@ -959,6 +961,8 @@ pub(crate) enum TyKind {
     Provider(Arc<Provider>),
     /// An instance of a provider. The contained `Ty` must have kind `TyKind::Provider`.
     ProviderInstance(Arc<Provider>),
+    /// The raw constructor for a provider.
+    ProviderRawConstructor(Name, Arc<Provider>),
 }
 
 impl_internable!(TyKind);

--- a/crates/starpls_hir/src/typeck/builtins.rs
+++ b/crates/starpls_hir/src/typeck/builtins.rs
@@ -103,9 +103,14 @@ impl BuiltinFunction {
                                     fields = Some(
                                         known_keys
                                             .iter()
-                                            .map(|(key, _)| ProviderField {
+                                            .map(|(key, value)| ProviderField {
                                                 name: Name::from_str(&key.value(db)),
-                                                doc: None,
+                                                doc: match value.kind() {
+                                                    TyKind::String(Some(s)) => Some(
+                                                        s.value(db).to_string().into_boxed_str(),
+                                                    ),
+                                                    _ => None,
+                                                },
                                             })
                                             .collect(),
                                     );

--- a/crates/starpls_hir/src/typeck/builtins.rs
+++ b/crates/starpls_hir/src/typeck/builtins.rs
@@ -103,14 +103,23 @@ impl BuiltinFunction {
                                     fields = Some(
                                         known_keys
                                             .iter()
-                                            .map(|(key, value)| ProviderField {
-                                                name: Name::from_str(&key.value(db)),
-                                                doc: match value.kind() {
-                                                    TyKind::String(Some(s)) => Some(
-                                                        s.value(db).to_string().into_boxed_str(),
-                                                    ),
-                                                    _ => None,
-                                                },
+                                            .flat_map(|(key, value)| {
+                                                let name = &key.value(db);
+                                                if !name.is_empty() {
+                                                    Some(ProviderField {
+                                                        name: Name::from_str(&key.value(db)),
+                                                        doc: match value.kind() {
+                                                            TyKind::String(Some(s)) => Some(
+                                                                s.value(db)
+                                                                    .to_string()
+                                                                    .into_boxed_str(),
+                                                            ),
+                                                            _ => None,
+                                                        },
+                                                    })
+                                                } else {
+                                                    None
+                                                }
                                             })
                                             .collect(),
                                     );

--- a/crates/starpls_hir/src/typeck/call.rs
+++ b/crates/starpls_hir/src/typeck/call.rs
@@ -3,7 +3,7 @@
 //! but with a couple of modifications for handling "*args" and "**kwargs" arguments.
 use crate::{
     def::{Argument, Param},
-    typeck::{builtins::BuiltinFunctionParam, intrinsics::IntrinsicFunctionParam, Rule},
+    typeck::{builtins::BuiltinFunctionParam, intrinsics::IntrinsicFunctionParam, Provider, Rule},
     Db, ExprId, Name,
 };
 use smallvec::{smallvec, SmallVec};
@@ -205,7 +205,24 @@ impl Slots {
                     providers: smallvec![],
                 }))
                 .collect(),
-            disable_errors: false,
+            disable_errors: true,
+        }
+    }
+
+    pub(crate) fn from_provider(provider: &Provider) -> Self {
+        Self {
+            slots: provider
+                .fields
+                .iter()
+                .flat_map(|fields| {
+                    fields.iter().map(|field| Slot::Keyword {
+                        name: field.name.clone(),
+                        provider: SlotProvider::Missing,
+                        positional: false,
+                    })
+                })
+                .collect(),
+            disable_errors: true,
         }
     }
 }

--- a/crates/starpls_hir/src/typeck/infer.rs
+++ b/crates/starpls_hir/src/typeck/infer.rs
@@ -578,7 +578,7 @@ impl TyCtxt<'_> {
 
                         self.none_ty()
                     }
-                    TyKind::Provider(provider) => {
+                    TyKind::Provider(provider) | TyKind::ProviderRawConstructor(_, provider) => {
                         TyKind::ProviderInstance(provider.clone()).intern()
                     }
                     TyKind::Unknown | TyKind::Any | TyKind::Unbound => self.unknown_ty(),
@@ -1246,7 +1246,9 @@ impl TyCtxt<'_> {
                     TyKind::IntrinsicFunction(func, _) => func.params(db)[..].into(),
                     TyKind::BuiltinFunction(func) => func.params(db)[..].into(),
                     TyKind::Rule(rule) => Slots::from_rule(db, rule),
-                    TyKind::Provider(provider) => Slots::from_provider(&provider),
+                    TyKind::Provider(provider) | TyKind::ProviderRawConstructor(_, provider) => {
+                        Slots::from_provider(&provider)
+                    }
                     _ => return None,
                 };
 

--- a/crates/starpls_hir/src/typeck/infer.rs
+++ b/crates/starpls_hir/src/typeck/infer.rs
@@ -1246,6 +1246,7 @@ impl TyCtxt<'_> {
                     TyKind::IntrinsicFunction(func, _) => func.params(db)[..].into(),
                     TyKind::BuiltinFunction(func) => func.params(db)[..].into(),
                     TyKind::Rule(rule) => Slots::from_rule(db, rule),
+                    TyKind::Provider(provider) => Slots::from_provider(&provider),
                     _ => return None,
                 };
 

--- a/crates/starpls_hir/src/typeck/infer.rs
+++ b/crates/starpls_hir/src/typeck/infer.rs
@@ -530,7 +530,7 @@ impl TyCtxt<'_> {
                             self.add_expr_diagnostic(file, expr, message);
                         }
 
-                        func.maybe_unique_ret_type(db, file, args_with_ty)
+                        func.maybe_unique_ret_type(db, file, expr, args_with_ty)
                             .unwrap_or_else(|| resolve_type_ref(db, &func.ret_type_ref(db)).0)
                     }
                     TyKind::Rule(rule) => {
@@ -578,7 +578,9 @@ impl TyCtxt<'_> {
 
                         self.none_ty()
                     }
-                    TyKind::Provider(_) => TyKind::ProviderInstance(callee_ty.clone()).intern(),
+                    TyKind::Provider(provider) => {
+                        TyKind::ProviderInstance(provider.clone()).intern()
+                    }
                     TyKind::Unknown | TyKind::Any | TyKind::Unbound => self.unknown_ty(),
                     _ => self.add_expr_diagnostic_ty(
                         file,

--- a/crates/starpls_hir/src/typeck/intrinsics.rs
+++ b/crates/starpls_hir/src/typeck/intrinsics.rs
@@ -395,7 +395,7 @@ s[0]*31^(n-1) + s[1]*31^(n-2) + ... + s[n-1]
 ```
 "#,
         vec![positional(Any)],
-        Int,
+        non_literal_int(),
     );
     // // TODO(withered-magic): SupportInt[T] -> T
     add_function(
@@ -435,8 +435,8 @@ int("0b111", 0)    # 7
 int("0x1234")      # error (invalid base 10 number)
 ```
 "#,
-        vec![positional(Any), positional_opt(Int)],
-        Int,
+        vec![positional(Any), positional_opt(non_literal_int())],
+        non_literal_int(),
     );
     add_function(
         "len",
@@ -444,7 +444,7 @@ int("0x1234")      # error (invalid base 10 number)
 
 It is a dynamic error if its argument is not a sequence."#,
         vec![positional(Any)],
-        Int,
+        non_literal_int(),
     );
     add_function(
         "list",
@@ -579,7 +579,11 @@ The `x in y` operator, where `y` is a range, reports whether `x` is equal to
 some member of the sequence `y`; the operation fails unless `x` is a
 number.
 "#,
-        vec![positional(Int), positional_opt(Int), positional_opt(Int)],
+        vec![
+            positional(non_literal_int()),
+            positional_opt(non_literal_int()),
+            positional_opt(non_literal_int()),
+        ],
         Range,
     );
     add_function(
@@ -772,10 +776,10 @@ They are interpreted according to Starlark's [indexing conventions](#indexing).
 "#,
                 vec![
                     positional(non_literal_string()),
-                    positional_opt(Int),
-                    positional_opt(Int),
+                    positional_opt(non_literal_int()),
+                    positional_opt(non_literal_int()),
                 ],
-                Int,
+                non_literal_int(),
                 0,
             ),
             function_field(
@@ -816,8 +820,8 @@ function reports whether any one of them is a suffix.
 "#,
                 vec![
                     positional(non_literal_string()),
-                    positional_opt(Int),
-                    positional_opt(Int),
+                    positional_opt(non_literal_int()),
+                    positional_opt(non_literal_int()),
                 ],
                 non_literal_bool(),
                 0,
@@ -842,10 +846,10 @@ If no occurrence is found, `found` returns -1.
 "#,
                 vec![
                     positional(non_literal_string()),
-                    positional_opt(Int),
-                    positional_opt(Int),
+                    positional_opt(non_literal_int()),
+                    positional_opt(non_literal_int()),
                 ],
-                Int,
+                non_literal_int(),
                 0,
             ),
             // TODO(withered-magic): Handle *args and **kwargs for format().
@@ -899,10 +903,10 @@ that if the substring is not found, the operation fails.
 "#,
                 vec![
                     positional(non_literal_string()),
-                    positional_opt(Int),
-                    positional_opt(Int),
+                    positional_opt(non_literal_int()),
+                    positional_opt(non_literal_int()),
                 ],
-                Int,
+                non_literal_int(),
                 0,
             ),
             function_field(
@@ -1137,7 +1141,7 @@ specifies a maximum number of occurrences to replace.
                 vec![
                     positional(non_literal_string()),
                     positional(non_literal_string()),
-                    positional_opt(Int),
+                    positional_opt(non_literal_int()),
                 ],
                 non_literal_string(),
                 0,
@@ -1157,10 +1161,10 @@ _last_ occurrence.
 "#,
                 vec![
                     positional(non_literal_string()),
-                    positional_opt(Int),
-                    positional_opt(Int),
+                    positional_opt(non_literal_int()),
+                    positional_opt(non_literal_int()),
                 ],
-                Int,
+                non_literal_int(),
                 0,
             ),
             function_field(
@@ -1178,10 +1182,10 @@ _last_ occurrence.
 "#,
                 vec![
                     positional(non_literal_string()),
-                    positional_opt(Int),
-                    positional_opt(Int),
+                    positional_opt(non_literal_int()),
+                    positional_opt(non_literal_int()),
                 ],
-                Int,
+                non_literal_int(),
                 0,
             ),
             function_field(
@@ -1214,7 +1218,10 @@ rightmost splits.
 "one two  three".rsplit(None, 1)             # ["one two", "three"]
 ```
 "#,
-                vec![positional(non_literal_string()), positional_opt(Int)],
+                vec![
+                    positional(non_literal_string()),
+                    positional_opt(non_literal_int()),
+                ],
                 List(Ty::string()),
                 0,
             ),
@@ -1264,7 +1271,10 @@ If `maxsplit` is given and non-negative, it specifies a maximum number of splits
 "banana".split("n", 1)                      # ["ba", "ana"]
 ```
 "#,
-                vec![positional_opt(non_literal_string()), positional_opt(Int)],
+                vec![
+                    positional_opt(non_literal_string()),
+                    positional_opt(non_literal_int()),
+                ],
                 List(Ty::string()),
                 0,
             ),
@@ -1313,8 +1323,8 @@ function reports whether any one of them is a prefix.
 "#,
                 vec![
                     positional(non_literal_string()),
-                    positional_opt(Int),
-                    positional_opt(Int),
+                    positional_opt(non_literal_int()),
+                    positional_opt(non_literal_int()),
                 ],
                 non_literal_bool(),
                 0,
@@ -1498,10 +1508,10 @@ x.index("a", -2)                        # 5 (bananA)
 "#,
                 vec![
                     positional(BoundVar(0)),
-                    positional_opt(Int),
-                    positional_opt(Int),
+                    positional_opt(non_literal_int()),
+                    positional_opt(non_literal_int()),
                 ],
-                Int,
+                non_literal_int(),
                 1,
             ),
             function_field(
@@ -1523,7 +1533,7 @@ x.insert(-1, "d")                       # None
 x                                       # ["a", "b", "c", "d", "e"]
 ```
 "#,
-                vec![positional(Int), positional(BoundVar(0))],
+                vec![positional(non_literal_int()), positional(BoundVar(0))],
                 None,
                 1,
             ),
@@ -1543,7 +1553,7 @@ x.pop()                                 # 2
 x                                       # [1]
 ```
 "#,
-                vec![positional_opt(Int)],
+                vec![positional_opt(non_literal_int())],
                 Any,
                 1,
             ),
@@ -1839,4 +1849,8 @@ fn non_literal_string() -> TyKind {
 
 fn non_literal_bool() -> TyKind {
     TyKind::Bool(None)
+}
+
+fn non_literal_int() -> TyKind {
+    TyKind::Int(None)
 }

--- a/crates/starpls_hir/src/typeck/tests.rs
+++ b/crates/starpls_hir/src/typeck/tests.rs
@@ -98,19 +98,19 @@ b"hello"
             0..4 "None": None
             5..9 "True": Literal[True]
             10..15 "False": Literal[False]
-            16..17 "0": int
+            16..17 "0": Literal[0]
             18..20 "0.": float
             21..28 "\"hello\"": Literal["hello"]
             29..37 "b\"hello\"": bytes
             39..44 "\"foo\"": Literal["foo"]
             46..51 "\"bar\"": Literal["bar"]
             38..52 "[\"foo\", \"bar\"]": list[string]
-            54..55 "1": int
-            57..58 "2": int
-            60..61 "3": int
-            53..62 "(1, 2, 3)": tuple[int, int, int]
+            54..55 "1": Literal[1]
+            57..58 "2": Literal[2]
+            60..61 "3": Literal[3]
+            53..62 "(1, 2, 3)": tuple[Literal[1], Literal[2], Literal[3]]
             64..67 "\"a\"": Literal["a"]
-            69..70 "1": int
+            69..70 "1": Literal[1]
             63..71 "{\"a\": 1}": dict[string, int]
         "#]],
     );
@@ -127,33 +127,33 @@ b, c = 2, 3
 h, i = [4, 5, 6]
 "#,
         expect![[r#"
-            1..2 "a": int
-            5..6 "1": int
-            7..8 "b": int
-            10..11 "c": int
-            7..11 "b, c": tuple[int, int]
-            14..15 "2": int
-            17..18 "3": int
-            14..18 "2, 3": tuple[int, int]
+            1..2 "a": Literal[1]
+            5..6 "1": Literal[1]
+            7..8 "b": Literal[2]
+            10..11 "c": Literal[3]
+            7..11 "b, c": tuple[Literal[2], Literal[3]]
+            14..15 "2": Literal[2]
+            17..18 "3": Literal[3]
+            14..18 "2, 3": tuple[Literal[2], Literal[3]]
             20..21 "d": Literal[True]
             19..22 "(d)": Any
             25..29 "True": Literal[True]
-            32..33 "e": int
+            32..33 "e": Literal[1]
             35..36 "f": Literal["a"]
             31..37 "[e, f]": list[Unknown]
-            39..40 "g": int
-            30..41 "([e, f], g)": tuple[list[Unknown], int]
-            46..47 "1": int
+            39..40 "g": Literal[3]
+            30..41 "([e, f], g)": tuple[list[Unknown], Literal[3]]
+            46..47 "1": Literal[1]
             49..52 "\"a\"": Literal["a"]
-            45..53 "(1, \"a\")": tuple[int, Literal["a"]]
-            55..56 "3": int
-            44..57 "((1, \"a\"), 3)": tuple[tuple[int, Literal["a"]], int]
+            45..53 "(1, \"a\")": tuple[Literal[1], Literal["a"]]
+            55..56 "3": Literal[3]
+            44..57 "((1, \"a\"), 3)": tuple[tuple[Literal[1], Literal["a"]], Literal[3]]
             58..59 "h": int
             61..62 "i": int
             58..62 "h, i": tuple[int, int]
-            66..67 "4": int
-            69..70 "5": int
-            72..73 "6": int
+            66..67 "4": Literal[4]
+            69..70 "5": Literal[5]
+            72..73 "6": Literal[6]
             65..74 "[4, 5, 6]": list[int]
         "#]],
     );
@@ -173,24 +173,24 @@ fn test_common_type() {
 "#,
         expect![[r#"
             1..3 "[]": list[Unknown]
-            5..6 "1": int
-            8..9 "2": int
+            5..6 "1": Literal[1]
+            8..9 "2": Literal[2]
             4..10 "[1, 2]": list[int]
-            12..13 "1": int
+            12..13 "1": Literal[1]
             15..18 "\"a\"": Literal["a"]
             11..19 "[1, \"a\"]": list[Unknown]
             20..22 "{}": dict[Any, Unknown]
             24..27 "\"a\"": Literal["a"]
-            29..30 "1": int
+            29..30 "1": Literal[1]
             23..31 "{\"a\": 1}": dict[string, int]
             33..36 "\"a\"": Literal["a"]
-            38..39 "1": int
+            38..39 "1": Literal[1]
             41..44 "\"b\"": Literal["b"]
             46..49 "\"c\"": Literal["c"]
             32..50 "{\"a\": 1, \"b\": \"c\"}": dict[string, Unknown]
             52..55 "\"a\"": Literal["a"]
-            57..58 "1": int
-            60..61 "1": int
+            57..58 "1": Literal[1]
+            60..61 "1": Literal[1]
             63..66 "\"a\"": Literal["a"]
             51..67 "{\"a\": 1, 1: \"a\"}": dict[Any, Unknown]
         "#]],
@@ -205,7 +205,7 @@ greeting = 1 # type: string
     "#,
         expect![[r#"
             1..9 "greeting": string
-            12..13 "1": int
+            12..13 "1": Literal[1]
 
             12..13 Expected value of type "string"
         "#]],
@@ -221,15 +221,15 @@ res2 = 2 + "y" # type: ignore
     "#,
         expect![[r#"
             1..5 "res1": Unknown
-            8..9 "1": int
+            8..9 "1": Literal[1]
             12..15 "\"x\"": Literal["x"]
             8..15 "1 + \"x\"": Unknown
             16..20 "res2": Unknown
-            23..24 "2": int
+            23..24 "2": Literal[2]
             27..30 "\"y\"": Literal["y"]
             23..30 "2 + \"y\"": Unknown
 
-            8..15 Operator "+" not supported for types "int" and "Literal["x"]"
+            8..15 Operator "+" not supported for types "Literal[1]" and "Literal["x"]"
         "#]],
     )
 }
@@ -246,8 +246,8 @@ def frobnicate(
     pass
 "#,
         expect![[r#"
-            1..4 "num": int
-            7..8 "1": int
+            1..4 "num": Literal[1]
+            7..8 "1": Literal[1]
 
             9..20 Unknown type "foo"
             42..43 Unknown type "bar"
@@ -280,7 +280,7 @@ bar(y)
 "#,
         expect![[r#"
             113..114 "x": int | None
-            117..118 "1": int
+            117..118 "1": Literal[1]
             138..141 "foo": def foo(x: int) -> None
             142..143 "x": int | None
             138..144 "foo(x)": None
@@ -288,7 +288,7 @@ bar(y)
             149..150 "x": int | None
             145..151 "bar(x)": None
             152..155 "bar": def bar(x: int | string | None) -> None
-            156..157 "2": int
+            156..157 "2": Literal[2]
             152..158 "bar(2)": None
             160..161 "y": int | string
             164..171 "\"hello\"": Literal["hello"]
@@ -317,12 +317,12 @@ foo(1, 2, 3, 4, d=5, e=6)
 "#,
         expect![[r#"
             46..49 "foo": def foo(a, b, *args: Unknown, d, **kwargs: Unknown) -> Unknown
-            50..51 "1": int
-            53..54 "2": int
-            56..57 "3": int
-            59..60 "4": int
-            64..65 "5": int
-            69..70 "6": int
+            50..51 "1": Literal[1]
+            53..54 "2": Literal[2]
+            56..57 "3": Literal[3]
+            59..60 "4": Literal[4]
+            64..65 "5": Literal[5]
+            69..70 "6": Literal[6]
             46..71 "foo(1, 2, 3, 4, d=5, e=6)": Unknown
         "#]],
     );
@@ -339,10 +339,10 @@ foo(1, 2, a=3, b=4)
 "#,
         expect![[r#"
             37..40 "foo": def foo(*args: Unknown, **kwargs: Unknown) -> Unknown
-            41..42 "1": int
-            44..45 "2": int
-            49..50 "3": int
-            54..55 "4": int
+            41..42 "1": Literal[1]
+            44..45 "2": Literal[2]
+            49..50 "3": Literal[3]
+            54..55 "4": Literal[4]
             37..56 "foo(1, 2, a=3, b=4)": Unknown
         "#]],
     );
@@ -360,10 +360,10 @@ foo(baz=1)
     "#,
         expect![[r#"
             25..28 "foo": def foo(bar) -> Unknown
-            29..30 "1": int
+            29..30 "1": Literal[1]
             25..31 "foo(1)": Unknown
             32..35 "foo": def foo(bar) -> Unknown
-            40..41 "1": int
+            40..41 "1": Literal[1]
             32..42 "foo(baz=1)": Unknown
 
             32..42 Argument missing for parameter(s) "bar"
@@ -385,14 +385,14 @@ foo(bar=4)
 "#,
         expect![[r#"
             28..31 "foo": def foo(*, bar) -> Unknown
-            32..33 "1": int
+            32..33 "1": Literal[1]
             28..34 "foo(1)": Unknown
             35..38 "foo": def foo(*, bar) -> Unknown
-            39..40 "2": int
-            46..47 "3": int
+            39..40 "2": Literal[2]
+            46..47 "3": Literal[3]
             35..48 "foo(2, bar=3)": Unknown
             49..52 "foo": def foo(*, bar) -> Unknown
-            57..58 "4": int
+            57..58 "4": Literal[4]
             49..59 "foo(bar=4)": Unknown
 
             28..34 Argument missing for parameter(s) "bar"
@@ -413,8 +413,8 @@ foo(bar=1, bar=2)
 "#,
         expect![[r#"
             25..28 "foo": def foo(bar) -> Unknown
-            33..34 "1": int
-            40..41 "2": int
+            33..34 "1": Literal[1]
+            40..41 "2": Literal[2]
             25..42 "foo(bar=1, bar=2)": Unknown
 
             40..41 Unexpected keyword argument "bar"
@@ -442,15 +442,15 @@ foo(**kwargs, *args)
             36..42 "kwargs": dict[Any, Unknown]
             45..47 "{}": dict[Any, Unknown]
             48..51 "foo": def foo(x, y) -> Unknown
-            54..55 "1": int
-            57..58 "2": int
+            54..55 "1": Literal[1]
+            57..58 "2": Literal[2]
             48..59 "foo(y=1, 2)": Unknown
             60..63 "foo": def foo(x, y) -> Unknown
             66..72 "kwargs": dict[Any, Unknown]
-            74..75 "2": int
+            74..75 "2": Literal[2]
             60..76 "foo(**kwargs, 2)": Unknown
             77..80 "foo": def foo(x, y) -> Unknown
-            83..84 "1": int
+            83..84 "1": Literal[1]
             87..91 "args": list[Unknown]
             77..92 "foo(y=1, *args)": Unknown
             93..96 "foo": def foo(x, y) -> Unknown
@@ -476,15 +476,15 @@ bar = dict(d = 4, e = "five", f = 6.)
 baz = dict()
 "#,
         expect![[r#"
-            1..4 "foo": dict[string, int]
+            1..4 "foo": dict[string, Unknown]
             7..11 "dict": def dict(x0: Iterable[Iterable[Any]] = None, **kwargs) -> dict[Unknown, Unknown]
-            16..17 "1": int
-            23..24 "2": int
-            30..31 "3": int
-            7..32 "dict(a = 1, b = 2, c = 3)": dict[string, int]
+            16..17 "1": Literal[1]
+            23..24 "2": Literal[2]
+            30..31 "3": Literal[3]
+            7..32 "dict(a = 1, b = 2, c = 3)": dict[string, Unknown]
             33..36 "bar": dict[string, Unknown]
             39..43 "dict": def dict(x0: Iterable[Iterable[Any]] = None, **kwargs) -> dict[Unknown, Unknown]
-            48..49 "4": int
+            48..49 "4": Literal[4]
             55..61 "\"five\"": Literal["five"]
             67..69 "6.": float
             39..70 "dict(d = 4, e = \"five\", f = 6.)": dict[string, Unknown]
@@ -506,13 +506,13 @@ z = x | y
 "#,
         expect![[r#"
             1..2 "a": int | string
-            5..6 "1": int
+            5..6 "1": Literal[1]
             34..35 "x": dict[string, int]
             39..42 "\"x\"": Literal["x"]
-            44..45 "1": int
+            44..45 "1": Literal[1]
             38..46 "{\"x\": 1}": dict[string, int]
             47..48 "y": dict[int, string]
-            52..53 "1": int
+            52..53 "1": Literal[1]
             55..58 "\"x\"": Literal["x"]
             51..59 "{1: \"x\"}": dict[int, string]
             60..61 "z": dict[string | int, int | string]
@@ -535,15 +535,15 @@ j = [i] + [""]
 "#,
         expect![[r#"
             1..2 "a": list[int]
-            6..7 "1": int
+            6..7 "1": Literal[1]
             5..8 "[1]": list[int]
-            12..13 "2": int
+            12..13 "2": Literal[2]
             11..14 "[2]": list[int]
             5..14 "[1] + [2]": list[int]
             15..16 "x": list[int | string]
-            20..21 "1": int
-            23..24 "2": int
-            26..27 "3": int
+            20..21 "1": Literal[1]
+            23..24 "2": Literal[2]
+            26..27 "3": Literal[3]
             19..28 "[1, 2, 3]": list[int]
             32..35 "\"a\"": Literal["a"]
             37..40 "\"b\"": Literal["b"]
@@ -552,10 +552,10 @@ j = [i] + [""]
             19..46 "[1, 2, 3] + [\"a\", \"b\", \"c\"]": list[int | string]
             51..52 "y": int | string
             55..56 "x": list[int | string]
-            57..58 "0": int
+            57..58 "0": Literal[0]
             55..59 "x[0]": int | string
             60..61 "i": int | string
-            64..65 "1": int
+            64..65 "1": Literal[1]
             87..88 "j": list[int | string]
             92..93 "i": int | string
             91..94 "[i]": list[int | string]
@@ -575,9 +575,9 @@ fn test_string_repetition() {
 "#,
         expect![[r#"
             1..6 "\"abc\"": Literal["abc"]
-            9..10 "3": int
+            9..10 "3": Literal[3]
             1..10 "\"abc\" * 3": string
-            11..12 "3": int
+            11..12 "3": Literal[3]
             15..20 "\"abc\"": Literal["abc"]
             11..20 "3 * \"abc\"": string
         "#]],
@@ -596,11 +596,11 @@ foo.c
         expect![[r#"
             1..4 "foo": struct
             7..13 "struct": def struct(**args, **kwargs) -> Unknown
-            18..19 "1": int
+            18..19 "1": Literal[1]
             25..30 "\"bar\"": Literal["bar"]
             7..31 "struct(a = 1, b = \"bar\")": struct
             32..35 "foo": struct
-            32..37 "foo.a": int
+            32..37 "foo.a": Literal[1]
             38..41 "foo": struct
             38..43 "foo.b": Literal["bar"]
             44..47 "foo": struct
@@ -664,6 +664,49 @@ info2 = DataInfo()
             114..119 "info2": DataInfo
             122..130 "DataInfo": Provider[DataInfo]
             122..132 "DataInfo()": DataInfo
+        "#]],
+    )
+}
+
+#[test]
+fn test_anonymous_provider() {
+    check_infer(
+        r#"
+providers = struct(DefaultInfo = provider())
+info = providers.DefaultInfo()
+
+providers = struct(result = provider(init = None))
+info1 = providers.result[0]()
+info2 = providers.result[1]()
+"#,
+        expect![[r#"
+            1..10 "providers": struct
+            13..19 "struct": def struct(**args, **kwargs) -> Unknown
+            34..42 "provider": def provider(**args, **kwargs) -> Unknown
+            34..44 "provider()": Provider[_]
+            13..45 "struct(DefaultInfo = provider())": struct
+            46..50 "info": _
+            53..62 "providers": struct
+            53..74 "providers.DefaultInfo": Provider[_]
+            53..76 "providers.DefaultInfo()": _
+            78..87 "providers": struct
+            90..96 "struct": def struct(**args, **kwargs) -> Unknown
+            106..114 "provider": def provider(**args, **kwargs) -> Unknown
+            122..126 "None": None
+            106..127 "provider(init = None)": tuple[Provider[_], ProviderRawConstructor]
+            90..128 "struct(result = provider(init = None))": struct
+            129..134 "info1": _
+            137..146 "providers": struct
+            137..153 "providers.result": tuple[Provider[_], ProviderRawConstructor]
+            154..155 "0": Literal[0]
+            137..156 "providers.result[0]": Provider[_]
+            137..158 "providers.result[0]()": _
+            159..164 "info2": _
+            167..176 "providers": struct
+            167..183 "providers.result": tuple[Provider[_], ProviderRawConstructor]
+            184..185 "1": Literal[1]
+            167..186 "providers.result[1]": ProviderRawConstructor
+            167..188 "providers.result[1]()": _
         "#]],
     )
 }


### PR DESCRIPTION
Fixes: https://github.com/withered-magic/starpls/issues/85

TODO:
- [x] Add `TyKind::Provider` and `TyKind::ProviderInstance`
- [x] Derive fields from dict
- [ ] ~~Derive fields from list~~ (won't do since the `dict` option is recommended)
- [x] Hover support
- [x] Autocomplete for `ProviderInstance` fields
- [x] Hover docs for `ProviderInstance` fields
- [x] Signature help for provider constructor
- [x] Attribute autocomplete when invoking `TyKind::Provider`s 
- [ ] ~~Resolve provider types in type comments~~
- [x] Handle different return type when `init` is passed (as described in https://bazel.build/rules/lib/globals/bzl.html#provider)
- [x] Plus tests for all of the above