### PR TITLE
don't complete intrinsic param names

### DIFF
--- a/crates/starpls_hir/src/typeck.rs
+++ b/crates/starpls_hir/src/typeck.rs
@@ -767,6 +767,16 @@ impl Param {
         }
     }
 
+    pub fn is_positional_only(&self, db: &dyn Db) -> bool {
+        match self.0 {
+            ParamInner::IntrinsicParam { parent, index } => matches!(
+                parent.params(db)[index],
+                IntrinsicFunctionParam::Positional { .. }
+            ),
+            _ => false,
+        }
+    }
+
     pub fn default_value(&self, db: &dyn Db) -> Option<String> {
         let common = common_attributes_query(db);
         let attr = match &self.0 {

--- a/crates/starpls_hir/src/typeck/intrinsics.rs
+++ b/crates/starpls_hir/src/typeck/intrinsics.rs
@@ -1565,7 +1565,7 @@ x                                       # [1]
 ```
 "#,
                 vec![positional_opt(non_literal_int())],
-                Any,
+                BoundVar(0),
                 1,
             ),
             function_field(
@@ -1689,7 +1689,7 @@ x.pop("four")                           # error: missing key
 ```
 "#,
                 vec![positional(BoundVar(0)), positional_opt(BoundVar(1))],
-                Any,
+                BoundVar(1),
                 2,
             ),
             function_field(

--- a/crates/starpls_ide/src/completions.rs
+++ b/crates/starpls_ide/src/completions.rs
@@ -124,7 +124,11 @@ pub(crate) fn completions(
             // Add completions for parameter names (excluding arg list and kwarg dict parameters).
             for name in params
                 .iter()
-                .filter(|param| !param.is_args_list(db) && !param.is_kwargs_dict(db))
+                .filter(|param| {
+                    !param.is_args_list(db)
+                        && !param.is_kwargs_dict(db)
+                        && !param.is_positional_only(db)
+                })
                 .filter_map(|param| param.name(db))
             {
                 items.push(CompletionItem {


### PR DESCRIPTION
We shouldn't autocomplete these since they are "fake" names anyways.