### PR TITLE
fix redundant diagnostic computations for unchanged files

### DIFF
--- a/crates/starpls/src/debouncer.rs
+++ b/crates/starpls/src/debouncer.rs
@@ -1,30 +1,37 @@
 use crate::event_loop::Task;
 use crossbeam_channel::{RecvError, RecvTimeoutError, Sender};
+use rustc_hash::FxHashSet;
+use starpls_common::FileId;
 use std::time::Duration;
 
 pub(crate) struct AnalysisDebouncer {
-    pub(crate) sender: Sender<()>,
+    pub(crate) sender: Sender<Vec<FileId>>,
 }
 
 impl AnalysisDebouncer {
     pub(crate) fn new(duration: Duration, sink: Sender<Task>) -> Self {
-        let (source_tx, source_rx) = crossbeam_channel::unbounded();
+        let (source_tx, source_rx) = crossbeam_channel::unbounded::<Vec<FileId>>();
 
         std::thread::spawn(move || {
             let mut active = false;
+            let mut pending_file_ids: FxHashSet<FileId> = FxHashSet::default();
             loop {
                 if active {
                     match source_rx.recv_timeout(duration) {
-                        Ok(_) => {}
+                        Ok(file_ids) => pending_file_ids.extend(file_ids.into_iter()),
                         Err(RecvTimeoutError::Disconnected) => break,
                         Err(RecvTimeoutError::Timeout) => {
-                            sink.send(Task::AnalysisRequested).unwrap();
+                            sink.send(Task::AnalysisRequested(pending_file_ids.drain().collect()))
+                                .unwrap();
                             active = false;
                         }
                     }
                 } else {
                     match source_rx.recv() {
-                        Ok(_) => active = true,
+                        Ok(file_ids) => {
+                            active = true;
+                            pending_file_ids.extend(file_ids.into_iter());
+                        }
                         Err(RecvError) => break,
                     }
                 }

--- a/crates/starpls/src/document.rs
+++ b/crates/starpls/src/document.rs
@@ -126,10 +126,6 @@ impl DocumentManager {
         self.documents.get(&file_id)
     }
 
-    pub(crate) fn iter(&self) -> impl Iterator<Item = (&FileId, &Document)> {
-        self.documents.iter()
-    }
-
     pub(crate) fn lookup_by_file_id(&self, file_id: FileId) -> PathBuf {
         self.path_interner.lookup_by_file_id(file_id)
     }


### PR DESCRIPTION
as part of introducing debouncing we introduced accidental behavior where diagnostics get recomputed for all open files (instead of the ones that just changed)

this PR reinstates the original behavior of only calculating diagnostics for changed files