### PR TITLE
support bzlmod through `bazel mod dump_repo_mapping`

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "629124c68ababa2289c66227ccce72f5c9adb7ebe1715a3a31f80fc8c79ffe70",
+  "checksum": "3377260485f0df9827523cf9cb45cd52662c4cfc72e73fd3b9bc2e30f0ecdced",
   "crates": {
     "addr2line 0.21.0": {
       "name": "addr2line",
@@ -453,13 +453,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "anyhow 1.0.79": {
+    "anyhow 1.0.81": {
       "name": "anyhow",
-      "version": "1.0.79",
+      "version": "1.0.81",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/anyhow/1.0.79/download",
-          "sha256": "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+          "url": "https://static.crates.io/crates/anyhow/1.0.81/download",
+          "sha256": "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
         }
       },
       "targets": [
@@ -497,14 +497,14 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.79",
+              "id": "anyhow 1.0.81",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.79"
+        "version": "1.0.81"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -3854,149 +3854,85 @@
           "**"
         ],
         "crate_features": {
-          "common": [],
+          "common": [
+            "extra_traits",
+            "std"
+          ],
           "selects": {
             "aarch64-apple-darwin": [
-              "default",
-              "extra_traits",
-              "std"
+              "default"
             ],
             "aarch64-apple-ios": [
-              "default",
-              "extra_traits",
-              "std"
+              "default"
             ],
             "aarch64-apple-ios-sim": [
-              "default",
-              "extra_traits",
-              "std"
+              "default"
             ],
             "aarch64-fuchsia": [
-              "default",
-              "extra_traits",
-              "std"
+              "default"
             ],
             "aarch64-linux-android": [
-              "default",
-              "extra_traits",
-              "std"
+              "default"
             ],
             "aarch64-unknown-linux-gnu": [
-              "default",
-              "std"
+              "default"
             ],
             "aarch64-unknown-nixos-gnu": [
-              "default",
-              "std"
+              "default"
             ],
             "aarch64-unknown-nto-qnx710": [
-              "default",
-              "extra_traits",
-              "std"
+              "default"
             ],
             "arm-unknown-linux-gnueabi": [
-              "default",
-              "std"
+              "default"
             ],
             "armv7-linux-androideabi": [
-              "default",
-              "extra_traits",
-              "std"
+              "default"
             ],
             "armv7-unknown-linux-gnueabi": [
-              "default",
-              "std"
+              "default"
             ],
             "i686-apple-darwin": [
-              "default",
-              "extra_traits",
-              "std"
+              "default"
             ],
             "i686-linux-android": [
-              "default",
-              "extra_traits",
-              "std"
+              "default"
             ],
             "i686-unknown-freebsd": [
-              "default",
-              "extra_traits",
-              "std"
+              "default"
             ],
             "i686-unknown-linux-gnu": [
-              "default",
-              "std"
+              "default"
             ],
             "powerpc-unknown-linux-gnu": [
-              "default",
-              "extra_traits",
-              "std"
-            ],
-            "riscv32imc-unknown-none-elf": [
-              "extra_traits",
-              "std"
-            ],
-            "riscv64gc-unknown-none-elf": [
-              "extra_traits",
-              "std"
+              "default"
             ],
             "s390x-unknown-linux-gnu": [
-              "default",
-              "extra_traits",
-              "std"
-            ],
-            "thumbv7em-none-eabi": [
-              "extra_traits",
-              "std"
-            ],
-            "thumbv8m.main-none-eabi": [
-              "extra_traits",
-              "std"
-            ],
-            "wasm32-unknown-unknown": [
-              "extra_traits",
-              "std"
+              "default"
             ],
             "wasm32-wasi": [
-              "default",
-              "extra_traits",
-              "std"
+              "default"
             ],
             "x86_64-apple-darwin": [
-              "default",
-              "extra_traits",
-              "std"
+              "default"
             ],
             "x86_64-apple-ios": [
-              "default",
-              "extra_traits",
-              "std"
+              "default"
             ],
             "x86_64-fuchsia": [
-              "default",
-              "extra_traits",
-              "std"
+              "default"
             ],
             "x86_64-linux-android": [
-              "default",
-              "extra_traits",
-              "std"
+              "default"
             ],
             "x86_64-unknown-freebsd": [
-              "default",
-              "extra_traits",
-              "std"
+              "default"
             ],
             "x86_64-unknown-linux-gnu": [
-              "default",
-              "std"
+              "default"
             ],
             "x86_64-unknown-nixos-gnu": [
-              "default",
-              "std"
-            ],
-            "x86_64-unknown-none": [
-              "extra_traits",
-              "std"
+              "default"
             ]
           }
         },
@@ -4089,13 +4025,40 @@
         ],
         "crate_features": {
           "common": [
-            "elf",
-            "errno",
             "general",
             "ioctl",
             "no_std"
           ],
-          "selects": {}
+          "selects": {
+            "aarch64-unknown-linux-gnu": [
+              "elf",
+              "errno"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "elf",
+              "errno"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "elf",
+              "errno"
+            ],
+            "armv7-unknown-linux-gnueabi": [
+              "elf",
+              "errno"
+            ],
+            "i686-unknown-linux-gnu": [
+              "elf",
+              "errno"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "elf",
+              "errno"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "elf",
+              "errno"
+            ]
+          }
         },
         "edition": "2021",
         "version": "0.4.13"
@@ -5760,7 +5723,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.79",
+              "id": "anyhow 1.0.81",
               "target": "anyhow"
             },
             {
@@ -5815,7 +5778,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.79",
+              "id": "anyhow 1.0.81",
               "target": "anyhow"
             },
             {
@@ -7540,7 +7503,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.79",
+              "id": "anyhow 1.0.81",
               "target": "anyhow"
             },
             {
@@ -7631,12 +7594,16 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.79",
+              "id": "anyhow 1.0.81",
               "target": "anyhow"
             },
             {
               "id": "bytes 1.5.0",
               "target": "bytes"
+            },
+            {
+              "id": "parking_lot 0.12.1",
+              "target": "parking_lot"
             },
             {
               "id": "prost 0.12.3",
@@ -7720,6 +7687,10 @@
         "deps": {
           "common": [
             {
+              "id": "anyhow 1.0.81",
+              "target": "anyhow"
+            },
+            {
               "id": "salsa-2022 0.1.0",
               "target": "salsa_2022",
               "alias": "salsa"
@@ -7754,6 +7725,10 @@
         ],
         "deps": {
           "common": [
+            {
+              "id": "anyhow 1.0.81",
+              "target": "anyhow"
+            },
             {
               "id": "crossbeam 0.8.3",
               "target": "crossbeam"
@@ -7834,6 +7809,10 @@
         ],
         "deps": {
           "common": [
+            {
+              "id": "anyhow 1.0.81",
+              "target": "anyhow"
+            },
             {
               "id": "dashmap 5.5.3",
               "target": "dashmap"
@@ -10699,7 +10678,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.79",
+              "id": "anyhow 1.0.81",
               "target": "anyhow"
             },
             {
@@ -11188,7 +11167,7 @@
     ]
   },
   "direct_deps": [
-    "anyhow 1.0.79",
+    "anyhow 1.0.81",
     "bytes 1.5.0",
     "cc 1.0.83",
     "clap 4.5.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,9 +94,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.79"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
 name = "arc-swap"
@@ -1404,6 +1404,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytes",
+ "parking_lot",
  "prost 0.12.3",
  "prost-build 0.12.3",
  "prost-types 0.12.3",
@@ -1418,6 +1419,7 @@ dependencies = [
 name = "starpls_common"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "salsa-2022",
  "starpls_syntax",
 ]
@@ -1426,6 +1428,7 @@ dependencies = [
 name = "starpls_hir"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "crossbeam",
  "dashmap",
  "either",
@@ -1448,6 +1451,7 @@ dependencies = [
 name = "starpls_ide"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "dashmap",
  "rustc-hash",
  "salsa-2022",

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ Steps to get up and running:
 - Loading external dependencies when `bzlmod` is enabled does not yet work correctly (coming soon, tracking in https://github.com/withered-magic/starpls/issues/168).
 - Type guards are not supported.
 - Type checker shows some false positives, especially when the definitions from the builtins proto are incorrect.
+- When `--enable-bzlmod` is set, type checking/goto definition may be slow for a given file the first time it is loaded. This is because resolution of repo mappings, done with `bazel mod dump_repo_mappings`, is done lazily.
+    - Additionally, when new dependencies are added, the language server needs to be restarted to refresh the mappings. This is due to the fact that repo mappings are cached, which is necessary to avoid slow type checking.
 
 ## Acknowledgements
 

--- a/crates/starpls/src/main.rs
+++ b/crates/starpls/src/main.rs
@@ -42,7 +42,7 @@ fn main() -> anyhow::Result<()> {
 }
 
 fn run_server() -> anyhow::Result<()> {
-    eprintln!("server: starpls, v0.1.7");
+    eprintln!("server: starpls, v0.1.8");
 
     // Create the transport over stdio.
     let (connection, io_threads) = Connection::stdio();

--- a/crates/starpls/src/server.rs
+++ b/crates/starpls/src/server.rs
@@ -73,7 +73,18 @@ impl Server {
 
         eprintln!("server: external output base: {:?}", external_output_base);
 
-        let bzlmod_enabled = workspace.join("MODULE.bazel").try_exists().unwrap_or(false);
+        let bzlmod_enabled = workspace.join("MODULE.bazel").try_exists().unwrap_or(false)
+            && {
+                eprintln!("server: checking for `bazel mod dump_repo_mapping` capability");
+                match bazel_client.dump_repo_mapping("") {
+                    Ok(_) => true,
+                    Err(_) => {
+                        eprintln!("server: installed Bazel version doesn't support `bazel mod dump_repo_mapping`, disabling bzlmod support");
+                        false
+                    }
+                }
+            };
+
         eprintln!("server: bzlmod_enabled = {}", bzlmod_enabled);
 
         // Additionally, load builtin rules.

--- a/crates/starpls/src/server.rs
+++ b/crates/starpls/src/server.rs
@@ -55,14 +55,14 @@ impl Server {
         let bazel_client = Arc::new(BazelCLI::default());
 
         // Determine the workspace root.
-        eprintln!("server: determining workspace root");
         let workspace = bazel_client.workspace().unwrap_or_else(|err| {
             eprintln!("server: failed to run `bazel info workspace`: {}", err);
             Default::default()
         });
 
+        eprintln!("server: workspace root: {:?}", workspace);
+
         // Determine the output base for the purpose of resolving external repositories.
-        eprintln!("server: determining workspace output_base");
         let external_output_base = bazel_client
             .output_base()
             .map(|output_base| output_base.join("external"))
@@ -71,17 +71,17 @@ impl Server {
                 Default::default()
             });
 
+        eprintln!("server: external output base: {:?}", external_output_base);
+
         let bzlmod_enabled = workspace.join("MODULE.bazel").try_exists().unwrap_or(false);
+        eprintln!("server: bzlmod_enabled = {}", bzlmod_enabled);
 
         // Additionally, load builtin rules.
-        eprintln!("server: running \"bazel info build-language\"");
+        eprintln!("server: fetching builtin rules via `bazel info build-language`");
         let rules = match load_bazel_build_language(&*bazel_client) {
             Ok(builtins) => builtins,
             Err(err) => {
-                eprintln!(
-                    "server: failed to run \"bazel info build-language\": {}",
-                    err
-                );
+                eprintln!("server: failed to run `bazel info build-language`: {}", err);
                 Default::default()
             }
         };

--- a/crates/starpls_bazel/BUILD.bazel
+++ b/crates/starpls_bazel/BUILD.bazel
@@ -42,6 +42,7 @@ rust_library(
         ":builtin_proto_rust",
         "@crates//:anyhow",
         "@crates//:bytes",
+        "@crates//:parking_lot",
         "@crates//:prost",
         "@crates//:serde",
         "@crates//:serde_json",

--- a/crates/starpls_bazel/Cargo.toml
+++ b/crates/starpls_bazel/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.79"
 bytes = "1.5.0"
+parking_lot = "0.12.1"
 prost = "0.12.3"
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.114"

--- a/crates/starpls_bazel/data/module-bazel.builtins.json
+++ b/crates/starpls_bazel/data/module-bazel.builtins.json
@@ -411,7 +411,7 @@
                         "is_star_star_arg": false
                     }
                 ],
-                "return_type": "None"
+                "return_type": "Unknown"
             }
         },
         {

--- a/crates/starpls_bazel/src/client.rs
+++ b/crates/starpls_bazel/src/client.rs
@@ -1,4 +1,8 @@
+use anyhow::anyhow;
+use parking_lot::RwLock;
+use serde_json::Deserializer;
 use std::{
+    collections::HashMap,
     path::{Path, PathBuf},
     process::Command,
 };
@@ -6,16 +10,24 @@ use std::{
 pub trait BazelClient: Send + Sync + 'static {
     fn build_language(&self) -> anyhow::Result<Vec<u8>>;
     fn output_base(&self) -> anyhow::Result<PathBuf>;
+    fn workspace(&self) -> anyhow::Result<PathBuf>;
+    fn resolve_repo_from_mapping(
+        &self,
+        apparent_repo: &str,
+        from_repo: &str,
+    ) -> anyhow::Result<Option<String>>;
 }
 
 pub struct BazelCLI {
     executable: PathBuf,
+    repo_mappings: RwLock<HashMap<String, HashMap<String, String>>>,
 }
 
 impl BazelCLI {
     pub fn new(executable: impl AsRef<Path>) -> Self {
         Self {
             executable: executable.as_ref().to_path_buf(),
+            ..Default::default()
         }
     }
 
@@ -34,12 +46,44 @@ impl BazelClient for BazelCLI {
         let output = self.run_command(&["info", "output_base"])?;
         Ok(String::from_utf8(output)?.trim().into())
     }
+
+    fn workspace(&self) -> anyhow::Result<PathBuf> {
+        let output = self.run_command(&["info", "workspace"])?;
+        Ok(String::from_utf8(output)?.trim().into())
+    }
+
+    fn resolve_repo_from_mapping(
+        &self,
+        apparent_repo: &str,
+        from_repo: &str,
+    ) -> anyhow::Result<Option<String>> {
+        // First, check if we've already fetched the repo mapping for the repository specified by `from_repo`.
+        let mappings = self.repo_mappings.read();
+        if let Some(mapping) = mappings.get(from_repo) {
+            return Ok(mapping.get(apparent_repo).cloned());
+        }
+        drop(mappings);
+
+        // Otherwise, fetch the repo mapping and cache it.
+        let output = self.run_command(&["mod", "dump_repo_mapping", from_repo])?;
+        let json = String::from_utf8(output)?;
+        let mut mappings = Deserializer::from_str(&json).into_iter::<HashMap<String, String>>();
+        let mapping = mappings
+            .next()
+            .ok_or_else(|| anyhow!("missing repo mapping for repository: {:?}", from_repo))??;
+        let canonical_repo = mapping.get(apparent_repo).cloned();
+        self.repo_mappings
+            .write()
+            .insert(from_repo.to_string(), mapping);
+        Ok(canonical_repo)
+    }
 }
 
 impl Default for BazelCLI {
     fn default() -> Self {
         Self {
             executable: "bazel".into(),
+            repo_mappings: Default::default(),
         }
     }
 }

--- a/crates/starpls_bazel/src/client.rs
+++ b/crates/starpls_bazel/src/client.rs
@@ -37,7 +37,7 @@ impl BazelCLI {
     }
 
     fn dump_repo_mapping(&self, repo: &str) -> anyhow::Result<HashMap<String, String>> {
-        let output = self.run_command(&["mod", "dump_repo_mapping", repo])?;
+        let output = self.run_command(&["mod", "--enable_bzlmod", "dump_repo_mapping", repo])?;
         let json = String::from_utf8(output)?;
         let mut mappings = Deserializer::from_str(&json).into_iter::<HashMap<String, String>>();
         Ok(mappings

--- a/crates/starpls_bazel/src/client.rs
+++ b/crates/starpls_bazel/src/client.rs
@@ -36,7 +36,7 @@ impl BazelCLI {
         Ok(output.stdout)
     }
 
-    fn dump_repo_mapping(&self, repo: &str) -> anyhow::Result<HashMap<String, String>> {
+    pub fn dump_repo_mapping(&self, repo: &str) -> anyhow::Result<HashMap<String, String>> {
         let output = self.run_command(&["mod", "--enable_bzlmod", "dump_repo_mapping", repo])?;
         let json = String::from_utf8(output)?;
         let mut mappings = Deserializer::from_str(&json).into_iter::<HashMap<String, String>>();

--- a/crates/starpls_common/BUILD.bazel
+++ b/crates/starpls_common/BUILD.bazel
@@ -10,6 +10,7 @@ rust_library(
     },
     deps = [
         "//crates/starpls_syntax",
+        "@crates//:anyhow",
         "@crates//:salsa",
     ],
 )

--- a/crates/starpls_common/Cargo.toml
+++ b/crates/starpls_common/Cargo.toml
@@ -6,5 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.81"
 salsa = { git = "https://github.com/withered-magic/salsa", package = "salsa-2022", rev = "91fdda90b344ef74e9bf35c3a5bb0fbae22ed6fb" }
 starpls_syntax = { path = "../starpls_syntax" }

--- a/crates/starpls_common/src/lib.rs
+++ b/crates/starpls_common/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, io};
+use std::fmt::Debug;
 
 use starpls_syntax::{
     line_index as syntax_line_index, parse_module, LineIndex, Module, ParseTree, SyntaxNode,
@@ -52,7 +52,8 @@ pub trait Db: salsa::DbWithJar<Jar> {
     fn update_file(&mut self, file_id: FileId, contents: String);
 
     /// Loads a file from the filesystem.
-    fn load_file(&self, path: &str, dialect: Dialect, from: FileId) -> io::Result<Option<File>>;
+    fn load_file(&self, path: &str, dialect: Dialect, from: FileId)
+        -> anyhow::Result<Option<File>>;
 
     /// Returns the `File` identified by the given `FileId`.
     fn get_file(&self, file_id: FileId) -> Option<File>;
@@ -61,7 +62,7 @@ pub trait Db: salsa::DbWithJar<Jar> {
         &self,
         path: &str,
         from: FileId,
-    ) -> io::Result<Option<Vec<LoadItemCandidate>>>;
+    ) -> anyhow::Result<Option<Vec<LoadItemCandidate>>>;
 }
 
 #[salsa::input]

--- a/crates/starpls_hir/BUILD.bazel
+++ b/crates/starpls_hir/BUILD.bazel
@@ -14,6 +14,7 @@ rust_library(
         "//crates/starpls_intern",
         "//crates/starpls_syntax",
         "//crates/starpls_test_util",
+        "@crates//:anyhow",
         "@crates//:crossbeam",
         "@crates//:dashmap",
         "@crates//:either",

--- a/crates/starpls_hir/Cargo.toml
+++ b/crates/starpls_hir/Cargo.toml
@@ -20,6 +20,7 @@ parking_lot = "0.12.1"
 smol_str = "0.2.0"
 smallvec = "1.11.2"
 either = "1.10.0"
+anyhow = "1.0.81"
 
 [dev-dependencies]
 expect-test = "1.4.1"

--- a/crates/starpls_hir/src/test_database.rs
+++ b/crates/starpls_hir/src/test_database.rs
@@ -3,7 +3,7 @@ use dashmap::{mapref::entry::Entry, DashMap};
 use starpls_bazel::Builtins;
 use starpls_common::{File, FileId, LoadItemCandidate};
 use starpls_test_util::builtins_with_catch_all_functions;
-use std::{io, sync::Arc};
+use std::sync::Arc;
 
 #[derive(Default)]
 #[salsa::db(starpls_common::Jar, crate::Jar)]
@@ -52,7 +52,12 @@ impl starpls_common::Db for TestDatabase {
         }
     }
 
-    fn load_file(&self, _path: &str, _dialect: Dialect, _from: FileId) -> io::Result<Option<File>> {
+    fn load_file(
+        &self,
+        _path: &str,
+        _dialect: Dialect,
+        _from: FileId,
+    ) -> anyhow::Result<Option<File>> {
         Ok(Some(File::new(
             self,
             FileId(0),
@@ -69,7 +74,7 @@ impl starpls_common::Db for TestDatabase {
         &self,
         _path: &str,
         _from: FileId,
-    ) -> io::Result<Option<Vec<LoadItemCandidate>>> {
+    ) -> anyhow::Result<Option<Vec<LoadItemCandidate>>> {
         Ok(None)
     }
 }

--- a/crates/starpls_hir/src/typeck/infer.rs
+++ b/crates/starpls_hir/src/typeck/infer.rs
@@ -142,6 +142,14 @@ impl TyCtxt<'_> {
             }
             Expr::ListComp { expr, .. } => TyKind::List(self.infer_expr(file, *expr)).intern(),
             Expr::Dict { entries } => {
+                if entries.len() > 32 {
+                    return self.set_expr_type(
+                        file,
+                        expr,
+                        Ty::dict(Ty::any(), Ty::unknown(), None),
+                    );
+                }
+
                 // Determine the dict's key type. For now, if all specified entries have the key type `T`, then we also
                 // use the type `T` as the dict's key tpe. Otherwise, we use `Any` as the key type.
                 // TODO(withered-magic): Eventually, we should use a union type here.

--- a/crates/starpls_ide/BUILD.bazel
+++ b/crates/starpls_ide/BUILD.bazel
@@ -14,6 +14,7 @@ rust_library(
         "//crates/starpls_hir",
         "//crates/starpls_syntax",
         "//crates/starpls_test_util",
+        "@crates//:anyhow",
         "@crates//:dashmap",
         "@crates//:rustc-hash",
         "@crates//:salsa",

--- a/crates/starpls_ide/Cargo.toml
+++ b/crates/starpls_ide/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.81"
 dashmap = "5.5.3"
 rustc-hash = "1.1.0"
 salsa = { git = "https://github.com/withered-magic/salsa", package = "salsa-2022", rev = "91fdda90b344ef74e9bf35c3a5bb0fbae22ed6fb" }

--- a/crates/starpls_ide/src/lib.rs
+++ b/crates/starpls_ide/src/lib.rs
@@ -6,7 +6,7 @@ use starpls_common::{Db, Diagnostic, Dialect, File, FileId, LoadItemCandidate};
 use starpls_hir::{BuiltinDefs, Db as _, ExprId, GlobalCtxt, LoadItemId, LoadStmt, ParamId, Ty};
 use starpls_syntax::{LineIndex, TextRange, TextSize};
 use starpls_test_util::builtins_with_catch_all_functions;
-use std::{fmt::Debug, io, panic, sync::Arc};
+use std::{fmt::Debug, panic, sync::Arc};
 
 pub use crate::{
     completions::{CompletionItem, CompletionItemKind, CompletionMode},
@@ -80,7 +80,12 @@ impl starpls_common::Db for Database {
         }
     }
 
-    fn load_file(&self, path: &str, dialect: Dialect, from: FileId) -> io::Result<Option<File>> {
+    fn load_file(
+        &self,
+        path: &str,
+        dialect: Dialect,
+        from: FileId,
+    ) -> anyhow::Result<Option<File>> {
         let (file_id, contents) = match self.loader.load_file(path, dialect, from)? {
             Some(res) => res,
             None => return Ok(None),
@@ -104,7 +109,7 @@ impl starpls_common::Db for Database {
         &self,
         path: &str,
         from: FileId,
-    ) -> io::Result<Option<Vec<LoadItemCandidate>>> {
+    ) -> anyhow::Result<Option<Vec<LoadItemCandidate>>> {
         let dialect = match self.get_file(from) {
             Some(file) => file.dialect(self),
             None => return Ok(None),
@@ -315,7 +320,7 @@ pub trait FileLoader: Send + Sync + 'static {
         path: &str,
         dialect: Dialect,
         from: FileId,
-    ) -> io::Result<Option<(FileId, Option<String>)>>;
+    ) -> anyhow::Result<Option<(FileId, Option<String>)>>;
 
     /// Returns a list of Starlark modules that can be loaded from the given `path`.
     fn list_load_candidates(
@@ -323,7 +328,7 @@ pub trait FileLoader: Send + Sync + 'static {
         path: &str,
         dialect: Dialect,
         from: FileId,
-    ) -> io::Result<Option<Vec<LoadItemCandidate>>>;
+    ) -> anyhow::Result<Option<Vec<LoadItemCandidate>>>;
 }
 
 /// [`FileLoader`] that looks up files by path from a hash map.
@@ -344,7 +349,7 @@ impl FileLoader for SimpleFileLoader {
         path: &str,
         _dialect: Dialect,
         _from: FileId,
-    ) -> io::Result<Option<(FileId, Option<String>)>> {
+    ) -> anyhow::Result<Option<(FileId, Option<String>)>> {
         Ok(self
             .file_set
             .get(path)
@@ -356,7 +361,7 @@ impl FileLoader for SimpleFileLoader {
         _path: &str,
         _dialect: Dialect,
         _from: FileId,
-    ) -> io::Result<Option<Vec<LoadItemCandidate>>> {
+    ) -> anyhow::Result<Option<Vec<LoadItemCandidate>>> {
         Ok(None)
     }
 }


### PR DESCRIPTION
Preliminary support for `bzlmod`. Adds support for goto definition and other features when `MODULE.bazel` exists and the `bazel mod dump_repo_mapping` command is supported.

Fixes: https://github.com/withered-magic/starpls/issues/168