### PR TITLE
Better checks for determining whether `bzlmod` is enabled

### DIFF
--- a/crates/starpls/src/server.rs
+++ b/crates/starpls/src/server.rs
@@ -85,7 +85,15 @@ impl Server {
         let bzlmod_enabled = bzlmod_capability && {
             // Next, we check if bzlmod is enabled by default for the current Bazel version.
             // bzlmod is enabled by default for Bazel versions 7 and later.
-            let bzlmod_enabled_by_default = info.release.starts_with("release 7");
+            // TODO(withered-magic): Just hardcoding this for now since I'm lazy to parse the actual versions.
+            // This should last us pretty long since Bazel 9 isn't anywhere on the horizon.
+            let bzlmod_enabled_by_default = ["release 7", "release 8", "release 9"]
+                .iter()
+                .any(|release| info.release.starts_with(release));
+
+            if bzlmod_enabled_by_default {
+                eprintln!("server: Bazel 7 or later detected")
+            }
 
             // Finally, check starlark-semantics to determine whether bzlmod has been explicitly
             // enabled/disabled, e.g. in a .bazelrc file.

--- a/crates/starpls_bazel/src/client.rs
+++ b/crates/starpls_bazel/src/client.rs
@@ -5,12 +5,19 @@ use std::{
     collections::HashMap,
     path::{Path, PathBuf},
     process::Command,
+    str,
 };
+
+pub struct BazelInfo {
+    pub output_base: PathBuf,
+    pub release: String,
+    pub starlark_semantics: String,
+    pub workspace: PathBuf,
+}
 
 pub trait BazelClient: Send + Sync + 'static {
     fn build_language(&self) -> anyhow::Result<Vec<u8>>;
-    fn output_base(&self) -> anyhow::Result<PathBuf>;
-    fn workspace(&self) -> anyhow::Result<PathBuf>;
+    fn info(&self) -> anyhow::Result<BazelInfo>;
     fn resolve_repo_from_mapping(
         &self,
         apparent_repo: &str,
@@ -51,14 +58,48 @@ impl BazelClient for BazelCLI {
         self.run_command(&["info", "build-language"])
     }
 
-    fn output_base(&self) -> anyhow::Result<PathBuf> {
-        let output = self.run_command(&["info", "output_base"])?;
-        Ok(String::from_utf8(output)?.trim().into())
-    }
+    fn info(&self) -> anyhow::Result<BazelInfo> {
+        let output = self.run_command(&[
+            "info",
+            "output_base",
+            "release",
+            "starlark-semantics",
+            "workspace",
+        ])?;
 
-    fn workspace(&self) -> anyhow::Result<PathBuf> {
-        let output = self.run_command(&["info", "workspace"])?;
-        Ok(String::from_utf8(output)?.trim().into())
+        let output = str::from_utf8(&output)?;
+        let mut output_base = None;
+        let mut release = None;
+        let mut starlark_semantics = None;
+        let mut workspace = None;
+        for line in output.lines() {
+            let (key, value) = match line.split_once(": ") {
+                Some(pair) => pair,
+                None => continue,
+            };
+            match key {
+                "output_base" => output_base = Some(value),
+                "release" => release = Some(value),
+                "starlark-semantics" => starlark_semantics = Some(value),
+                "workspace" => workspace = Some(value),
+                _ => {}
+            }
+        }
+
+        Ok(BazelInfo {
+            output_base: output_base
+                .ok_or_else(|| anyhow!("failed to determine output_base from `bazel info`"))?
+                .into(),
+            release: release
+                .ok_or_else(|| anyhow!("failed to determine release from `bazel info`"))?
+                .into(),
+            starlark_semantics: starlark_semantics
+                .ok_or_else(|| anyhow!("failed to determine starlark-semantics from `bazel info`"))?
+                .into(),
+            workspace: workspace
+                .ok_or_else(|| anyhow!("failed to determine workspace from `bazel info`"))?
+                .into(),
+        })
     }
 
     fn resolve_repo_from_mapping(

--- a/crates/starpls_bazel/src/client.rs
+++ b/crates/starpls_bazel/src/client.rs
@@ -8,6 +8,7 @@ use std::{
     str,
 };
 
+#[derive(Default)]
 pub struct BazelInfo {
     pub output_base: PathBuf,
     pub release: String,


### PR DESCRIPTION
As discussed in https://github.com/withered-magic/starpls/issues/195, uses a combination of `release` and `starlark-semantics` from `bazel info` to better determine if `bzlmod` is enabled.