### PR TITLE
Introduce data-flow analysis

### DIFF
--- a/crates/starpls/src/main.rs
+++ b/crates/starpls/src/main.rs
@@ -48,12 +48,9 @@ pub(crate) struct ServerArgs {
     bazel_path: Option<String>,
     /// Infer attributes on a rule implementation function's context parameter.
     #[clap(long = "experimental_infer_ctx_attributes", default_value_t = false)]
-    experimental_infer_ctx_attributes: bool,
-    #[clap(
-        long = "experimental_enable_dataflow_analysis",
-        default_value_t = false
-    )]
-    experimental_enable_dataflow_analysis: bool,
+    infer_ctx_attributes: bool,
+    #[clap(long = "experimental_use_code_flow_analysis", default_value_t = false)]
+    use_code_flow_analysis: bool,
 }
 
 fn main() -> anyhow::Result<()> {

--- a/crates/starpls/src/main.rs
+++ b/crates/starpls/src/main.rs
@@ -49,6 +49,11 @@ pub(crate) struct ServerArgs {
     /// Infer attributes on a rule implementation function's context parameter.
     #[clap(long = "experimental_infer_ctx_attributes", default_value_t = false)]
     experimental_infer_ctx_attributes: bool,
+    #[clap(
+        long = "experimental_enable_dataflow_analysis",
+        default_value_t = false
+    )]
+    experimental_enable_dataflow_analysis: bool,
 }
 
 fn main() -> anyhow::Result<()> {

--- a/crates/starpls/src/server.rs
+++ b/crates/starpls/src/server.rs
@@ -173,8 +173,8 @@ impl Server {
         let mut analysis = Analysis::new(
             Arc::new(loader),
             InferenceOptions {
-                infer_ctx_attrs: config.args.experimental_infer_ctx_attributes,
-                use_code_flow_analysis: false,
+                infer_ctx_attributes: config.args.infer_ctx_attributes,
+                use_code_flow_analysis: config.args.use_code_flow_analysis,
             },
         );
 

--- a/crates/starpls/src/server.rs
+++ b/crates/starpls/src/server.rs
@@ -174,6 +174,7 @@ impl Server {
             Arc::new(loader),
             InferenceOptions {
                 infer_ctx_attrs: config.args.experimental_infer_ctx_attributes,
+                use_code_flow_analysis: false,
             },
         );
 

--- a/crates/starpls_hir/src/def.rs
+++ b/crates/starpls_hir/src/def.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashSet, ops::Index};
 
+use either::Either;
 use id_arena::{Arena, Id};
 use rustc_hash::FxHashMap;
 use smol_str::SmolStr;
@@ -11,6 +12,7 @@ use starpls_syntax::{
 
 use crate::{typeck::TypeRef, Db, Ty, TyKind};
 
+pub(crate) mod codeflow;
 mod lower;
 pub(crate) mod resolver;
 pub(crate) mod scope;
@@ -265,8 +267,7 @@ pub(crate) enum Stmt {
     If {
         test: ExprId,
         if_stmts: Box<[StmtId]>,
-        elif_stmt: Option<StmtId>,
-        else_stmts: Box<[StmtId]>,
+        elif_or_else_stmts: Option<Either<StmtId, Box<[StmtId]>>>,
     },
     For {
         iterable: ExprId,

--- a/crates/starpls_hir/src/def/codeflow.rs
+++ b/crates/starpls_hir/src/def/codeflow.rs
@@ -72,8 +72,16 @@ impl<'a> CodeFlowLowerCtx<'a> {
     }
 
     fn lower_stmts(&mut self, stmts: &[StmtId]) {
+        // Lower each statement in the list, stopping if we see unreachable code.
         for stmt in stmts {
             self.lower_stmt(*stmt);
+
+            // If we find ourselves at an unreachable flow node, all remaining statements
+            // are unreachable. Unreachable statements in general are not represented
+            // in the code flow graph, so we can simply exit here.
+            if self.result.flow_nodes[self.curr_node] == FlowNode::Unreachable {
+                break;
+            }
         }
     }
 

--- a/crates/starpls_hir/src/def/codeflow.rs
+++ b/crates/starpls_hir/src/def/codeflow.rs
@@ -1,0 +1,460 @@
+use either::Either;
+use id_arena::{Arena, Id};
+use rustc_hash::FxHashMap;
+use starpls_common::File;
+
+use crate::{
+    def::{
+        scope::{module_scopes, ExecutionScopeId, ScopeHirId, Scopes},
+        CompClause, Expr, Stmt, StmtId,
+    },
+    lower, Db, ExprId, Module, Name,
+};
+
+#[allow(unused)]
+pub(crate) mod pretty;
+
+pub(crate) type FlowNodeId = Id<FlowNode>;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum FlowNode {
+    Start,
+    Assign {
+        expr: ExprId,
+        name: Name,
+        execution_scope: ExecutionScopeId,
+        source: ExprId,
+        antecedent: FlowNodeId,
+    },
+    Branch {
+        antecedents: Vec<FlowNodeId>,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct CodeFlowGraph {
+    pub(crate) flow_nodes: Arena<FlowNode>,
+    pub(crate) expr_to_node: FxHashMap<ExprId, FlowNodeId>,
+    pub(crate) hir_to_flow_node: FxHashMap<ScopeHirId, FlowNodeId>,
+}
+
+#[allow(unused)]
+struct CodeFlowLowerCtx<'a> {
+    module: &'a Module,
+    scopes: &'a Scopes,
+    result: CodeFlowGraph,
+    curr_node: FlowNodeId,
+    curr_break_target: Option<FlowNodeId>,
+    curr_continue_target: Option<FlowNodeId>,
+}
+
+impl<'a> CodeFlowLowerCtx<'a> {
+    fn new(module: &'a Module, scopes: &'a Scopes) -> Self {
+        let mut flow_nodes = Arena::new();
+        let curr_node = flow_nodes.alloc(FlowNode::Start);
+        let cfg = CodeFlowGraph {
+            flow_nodes,
+            expr_to_node: Default::default(),
+            hir_to_flow_node: Default::default(),
+        };
+        CodeFlowLowerCtx {
+            module,
+            scopes,
+            result: cfg,
+            curr_node,
+            curr_break_target: None,
+            curr_continue_target: None,
+        }
+    }
+
+    fn lower_stmts(&mut self, stmts: &[StmtId]) {
+        for stmt in stmts {
+            self.lower_stmt(*stmt);
+        }
+    }
+
+    fn lower_stmt(&mut self, stmt: StmtId) {
+        match &self.module[stmt] {
+            Stmt::Assign { lhs, rhs, .. } => {
+                self.lower_assignment_target(*lhs, *rhs);
+            }
+            Stmt::Def { stmts, .. } => {
+                self.with_new_start_node(|this| {
+                    this.lower_stmts(stmts);
+                    stmt
+                });
+            }
+            Stmt::If {
+                test,
+                if_stmts,
+                elif_or_else_stmts,
+            } => {
+                self.lower_expr(*test);
+
+                let pre_if_node = self.curr_node;
+                let post_if_node = self.new_flow_node(FlowNode::Branch {
+                    antecedents: Vec::new(),
+                });
+                self.lower_stmts(if_stmts);
+                self.push_antecedent(post_if_node, self.curr_node);
+                match elif_or_else_stmts {
+                    Some(Either::Left(elif_stmt)) => {
+                        self.curr_node = pre_if_node;
+                        self.lower_stmt(*elif_stmt);
+                        self.push_antecedent(post_if_node, self.curr_node);
+                    }
+                    Some(Either::Right(else_stmts)) => {
+                        self.curr_node = pre_if_node;
+                        self.lower_stmts(&else_stmts);
+                        self.push_antecedent(post_if_node, self.curr_node);
+                    }
+                    _ => {
+                        self.push_antecedent(post_if_node, pre_if_node);
+                    }
+                }
+
+                self.curr_node = post_if_node;
+            }
+            Stmt::Return { expr } => {
+                if let Some(expr) = expr {
+                    self.lower_expr(*expr);
+                }
+            }
+            Stmt::Expr { expr } => {
+                self.lower_expr(*expr);
+            }
+            Stmt::For {
+                iterable,
+                targets,
+                stmts,
+            } => {
+                for target in targets.iter() {
+                    self.lower_assignment_target(*target, *iterable);
+                }
+                self.lower_stmts(stmts);
+            }
+            _ => {}
+        }
+    }
+
+    fn lower_expr(&mut self, expr: ExprId) {
+        match &self.module[expr] {
+            Expr::Name { .. } => {
+                self.result.expr_to_node.insert(expr, self.curr_node);
+            }
+            Expr::DictComp {
+                entry,
+                comp_clauses,
+            } => {
+                self.lower_comp_clauses(comp_clauses);
+                self.lower_expr(entry.key);
+                self.lower_expr(entry.value);
+            }
+            Expr::ListComp { expr, comp_clauses } => {
+                self.lower_comp_clauses(comp_clauses);
+                self.lower_expr(*expr);
+            }
+            expr => expr.walk_child_exprs(|expr| {
+                self.lower_expr(expr);
+            }),
+        }
+    }
+
+    fn lower_assignment_target(&mut self, expr: ExprId, source: ExprId) {
+        self.lower_expr(source);
+        match &self.module[expr] {
+            Expr::Name { ref name } => {
+                let assign_node = self.new_flow_node(FlowNode::Assign {
+                    expr,
+                    name: name.clone(),
+                    execution_scope: self.scopes.execution_scope_for_expr(expr).unwrap(),
+                    source,
+                    antecedent: self.curr_node,
+                });
+                self.curr_node = assign_node;
+                self.result.expr_to_node.insert(expr, self.curr_node);
+            }
+            Expr::Paren { expr } => {
+                self.lower_assignment_target(*expr, source);
+            }
+            Expr::Tuple { exprs } | Expr::List { exprs } => {
+                for expr in exprs.iter() {
+                    self.lower_assignment_target(*expr, source);
+                }
+            }
+            expr => expr.walk_child_exprs(|expr| {
+                self.lower_expr(expr);
+            }),
+        }
+    }
+
+    fn lower_comp_clauses(&mut self, comp_clauses: &[CompClause]) {
+        for comp_clause in comp_clauses.into_iter() {
+            match comp_clause {
+                CompClause::For { iterable, targets } => {
+                    self.lower_expr(*iterable);
+                    for target in targets.iter() {
+                        self.lower_assignment_target(*target, *iterable);
+                    }
+                }
+                CompClause::If { test } => {
+                    self.lower_expr(*test);
+                }
+            }
+        }
+    }
+
+    fn new_flow_node(&mut self, data: FlowNode) -> FlowNodeId {
+        self.result.flow_nodes.alloc(data)
+    }
+
+    fn push_antecedent(&mut self, this: FlowNodeId, antecedent: FlowNodeId) {
+        match self.result.flow_nodes[this] {
+            FlowNode::Branch {
+                ref mut antecedents,
+            } => {
+                if !antecedents.contains(&antecedent) {
+                    antecedents.push(antecedent);
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn with_new_start_node<F, T>(&mut self, mut f: F)
+    where
+        F: FnMut(&mut Self) -> T,
+        T: Into<ScopeHirId>,
+    {
+        let saved_curr_node = self.curr_node;
+        self.curr_node = self.new_flow_node(FlowNode::Start);
+        let hir = f(self).into();
+        self.result.hir_to_flow_node.insert(hir, self.curr_node);
+        self.curr_node = saved_curr_node;
+    }
+}
+
+pub(crate) fn lower_to_code_flow_graph(module: &Module, scopes: &Scopes) -> CodeFlowGraph {
+    let mut cx = CodeFlowLowerCtx::new(module, scopes);
+    cx.lower_stmts(&module.top_level);
+    cx.result
+        .hir_to_flow_node
+        .insert(ScopeHirId::Module, cx.curr_node);
+    cx.result
+}
+
+#[salsa::tracked]
+pub(crate) struct CodeFlowGraphResult {
+    #[return_ref]
+    pub(crate) cfg: CodeFlowGraph,
+}
+
+#[allow(unused)]
+#[salsa::tracked]
+pub(crate) fn code_flow_graph(db: &dyn Db, file: File) -> CodeFlowGraphResult {
+    let info = lower(db, file);
+    let scopes = module_scopes(db, file);
+    let cfg = lower_to_code_flow_graph(info.module(db), scopes.scopes(db));
+    CodeFlowGraphResult::new(db, cfg)
+}
+
+#[cfg(test)]
+mod tests {
+    use expect_test::{expect, Expect};
+    use starpls_common::{Dialect, FileId};
+
+    use super::*;
+    use crate::test_database::TestDatabase;
+
+    fn check(input: &str, expect: Expect) {
+        let db = TestDatabase::default();
+        let file_id = FileId(0);
+        let file = File::new(&db, file_id, Dialect::Standard, None, input.to_string());
+        let res = code_flow_graph(&db, file);
+        let cfg = res.cfg(&db);
+        expect.assert_eq(&cfg.pretty_print());
+    }
+
+    #[test]
+    fn test_empty() {
+        check(
+            r#""#,
+            expect![[r#"
+            def main():
+                'bb0: {
+                    data: Start
+                    antecedents: []
+                }
+
+        "#]],
+        );
+    }
+
+    #[test]
+    fn test_assign() {
+        check(
+            r#"
+x = 1
+y = "a"
+"#,
+            expect![[r#"
+                def main():
+                    'bb0: {
+                        data: Start
+                        antecedents: []
+                    }
+
+                    'bb1: {
+                        data: Assign { expr: Id { idx: 0 }, name: Name("x"), execution_scope: Module, source: Id { idx: 1 }, antecedent: Id { idx: 0 } }
+                        antecedents: ['bb0]
+                    }
+
+                    'bb2: {
+                        data: Assign { expr: Id { idx: 2 }, name: Name("y"), execution_scope: Module, source: Id { idx: 3 }, antecedent: Id { idx: 1 } }
+                        antecedents: ['bb1]
+                    }
+
+            "#]],
+        );
+    }
+
+    #[test]
+    fn test_if_only() {
+        check(
+            r#"
+if x > 0:
+    y = 1
+"#,
+            expect![[r#"
+                def main():
+                    'bb0: {
+                        data: Start
+                        antecedents: []
+                    }
+
+                    'bb1: {
+                        data: Branch { antecedents: [Id { idx: 2 }, Id { idx: 0 }] }
+                        antecedents: ['bb2, 'bb0]
+                    }
+
+                    'bb2: {
+                        data: Assign { expr: Id { idx: 3 }, name: Name("y"), execution_scope: Module, source: Id { idx: 4 }, antecedent: Id { idx: 0 } }
+                        antecedents: ['bb0]
+                    }
+
+            "#]],
+        );
+    }
+
+    #[test]
+    fn test_separate_execution_scope() {
+        check(
+            r#"
+def f():
+    x = 1
+    y = 2
+
+x = 3
+y = 4
+"#,
+            expect![[r#"
+                def main():
+                    'bb0: {
+                        data: Start
+                        antecedents: []
+                    }
+
+                    'bb1: {
+                        data: Start
+                        antecedents: []
+                    }
+
+                    'bb2: {
+                        data: Assign { expr: Id { idx: 0 }, name: Name("x"), execution_scope: Def(Id { idx: 2 }), source: Id { idx: 1 }, antecedent: Id { idx: 1 } }
+                        antecedents: ['bb1]
+                    }
+
+                    'bb3: {
+                        data: Assign { expr: Id { idx: 2 }, name: Name("y"), execution_scope: Def(Id { idx: 2 }), source: Id { idx: 3 }, antecedent: Id { idx: 2 } }
+                        antecedents: ['bb2]
+                    }
+
+                    'bb4: {
+                        data: Assign { expr: Id { idx: 4 }, name: Name("x"), execution_scope: Module, source: Id { idx: 5 }, antecedent: Id { idx: 0 } }
+                        antecedents: ['bb0]
+                    }
+
+                    'bb5: {
+                        data: Assign { expr: Id { idx: 6 }, name: Name("y"), execution_scope: Module, source: Id { idx: 7 }, antecedent: Id { idx: 4 } }
+                        antecedents: ['bb4]
+                    }
+
+            "#]],
+        );
+    }
+
+    #[test]
+    fn test_list_comp() {
+        check(
+            r#"
+nums = [x for x in range(10)]        
+"#,
+            expect![[r#"
+                def main():
+                    'bb0: {
+                        data: Start
+                        antecedents: []
+                    }
+
+                    'bb1: {
+                        data: Assign { expr: Id { idx: 5 }, name: Name("x"), execution_scope: Comp(Id { idx: 6 }), source: Id { idx: 4 }, antecedent: Id { idx: 0 } }
+                        antecedents: ['bb0]
+                    }
+
+                    'bb2: {
+                        data: Assign { expr: Id { idx: 0 }, name: Name("nums"), execution_scope: Module, source: Id { idx: 6 }, antecedent: Id { idx: 1 } }
+                        antecedents: ['bb1]
+                    }
+
+            "#]],
+        )
+    }
+
+    #[test]
+    fn test_for_stmt() {
+        check(
+            r#"
+for x, y in [[1, 2], [3, 4]]:
+    nums = [(x * y * i) for i in range(5)]
+"#,
+            expect![[r#"
+                def main():
+                    'bb0: {
+                        data: Start
+                        antecedents: []
+                    }
+
+                    'bb1: {
+                        data: Assign { expr: Id { idx: 7 }, name: Name("x"), execution_scope: Module, source: Id { idx: 6 }, antecedent: Id { idx: 0 } }
+                        antecedents: ['bb0]
+                    }
+
+                    'bb2: {
+                        data: Assign { expr: Id { idx: 8 }, name: Name("y"), execution_scope: Module, source: Id { idx: 6 }, antecedent: Id { idx: 1 } }
+                        antecedents: ['bb1]
+                    }
+
+                    'bb3: {
+                        data: Assign { expr: Id { idx: 19 }, name: Name("i"), execution_scope: Comp(Id { idx: 20 }), source: Id { idx: 18 }, antecedent: Id { idx: 2 } }
+                        antecedents: ['bb2]
+                    }
+
+                    'bb4: {
+                        data: Assign { expr: Id { idx: 9 }, name: Name("nums"), execution_scope: Module, source: Id { idx: 20 }, antecedent: Id { idx: 3 } }
+                        antecedents: ['bb3]
+                    }
+
+            "#]],
+        );
+    }
+}

--- a/crates/starpls_hir/src/def/codeflow/pretty.rs
+++ b/crates/starpls_hir/src/def/codeflow/pretty.rs
@@ -1,0 +1,87 @@
+use std::fmt::Write;
+
+use crate::def::codeflow::{CodeFlowGraph, FlowNode, FlowNodeId};
+
+macro_rules! w {
+    ($dst:expr, $($arg:tt)*) => {
+        { let _ = write!($dst, $($arg)*); }
+    };
+}
+
+macro_rules! wln {
+    ($dst:expr) => {
+        { let _ = writeln!($dst); }
+    };
+    ($dst:expr, $($arg:tt)*) => {
+        { let _ = writeln!($dst, $($arg)*); }
+    };
+}
+
+impl CodeFlowGraph {
+    pub(crate) fn pretty_print(&self) -> String {
+        CodeFlowGraphPrettyCtx {
+            cfg: self,
+            result: String::new(),
+            indent: String::new(),
+        }
+        .pretty_print()
+    }
+}
+
+struct CodeFlowGraphPrettyCtx<'a> {
+    cfg: &'a CodeFlowGraph,
+    result: String,
+    indent: String,
+}
+
+impl<'a> CodeFlowGraphPrettyCtx<'a> {
+    fn pretty_print(mut self) -> String {
+        wln!(&mut self.result, "def main():");
+        self.push_indent_level();
+        self.format_flow_nodes();
+        self.result
+    }
+
+    fn format_flow_nodes(&mut self) {
+        for (id, flow_node) in &self.cfg.flow_nodes {
+            let formatted_id = self.format_flow_node_id(id);
+            wln!(&mut self.result, "{}{}: {{", self.indent, formatted_id);
+            self.push_indent_level();
+            wln!(&mut self.result, "{}data: {:?}", self.indent, flow_node);
+            w!(&mut self.result, "{}antecedents: [", self.indent);
+            match flow_node {
+                FlowNode::Assign { antecedent, .. } => {
+                    self.result.push_str(&self.format_flow_node_id(*antecedent));
+                }
+                FlowNode::Branch { antecedents } => {
+                    for (i, antecedent) in antecedents.iter().enumerate() {
+                        if i > 0 {
+                            self.result.push_str(", ");
+                        }
+                        self.result.push_str(&self.format_flow_node_id(*antecedent));
+                    }
+                }
+                _ => {}
+            }
+
+            self.result.push_str("]\n");
+            self.pop_indent_level();
+            wln!(&mut self.result, "{}}}", self.indent);
+            self.result.push('\n');
+        }
+    }
+
+    fn format_flow_node_id(&self, id: FlowNodeId) -> String {
+        format!("'bb{}", id.index())
+    }
+
+    fn push_indent_level(&mut self) {
+        self.indent.push_str("    ");
+    }
+
+    fn pop_indent_level(&mut self) {
+        for _ in 0..4 {
+            self.indent.pop();
+        }
+    }
+}

--- a/crates/starpls_hir/src/def/codeflow/pretty.rs
+++ b/crates/starpls_hir/src/def/codeflow/pretty.rs
@@ -53,7 +53,7 @@ impl<'a> CodeFlowGraphPrettyCtx<'a> {
                 FlowNode::Assign { antecedent, .. } => {
                     self.result.push_str(&self.format_flow_node_id(*antecedent));
                 }
-                FlowNode::Branch { antecedents } => {
+                FlowNode::Branch { antecedents } | FlowNode::Loop { antecedents } => {
                     for (i, antecedent) in antecedents.iter().enumerate() {
                         if i > 0 {
                             self.result.push_str(", ");

--- a/crates/starpls_hir/src/display.rs
+++ b/crates/starpls_hir/src/display.rs
@@ -86,6 +86,7 @@ impl DisplayWithDb for TyKind {
             TyKind::Unbound => "Unbound",
             TyKind::Unknown => "Unknown",
             TyKind::Any => "Any",
+            TyKind::Never => "Never",
             TyKind::None => "None",
             TyKind::Bool(Some(b)) => {
                 f.write_str("Literal[")?;

--- a/crates/starpls_hir/src/lib.rs
+++ b/crates/starpls_hir/src/lib.rs
@@ -37,6 +37,8 @@ pub struct Jar(
     def::Function,
     def::LoadStmt,
     def::LiteralString,
+    def::codeflow::CodeFlowGraphResult,
+    def::codeflow::code_flow_graph,
     def::scope::ModuleScopes,
     def::scope::module_scopes,
     def::scope::module_scopes_query,

--- a/crates/starpls_hir/src/typeck.rs
+++ b/crates/starpls_hir/src/typeck.rs
@@ -636,6 +636,18 @@ impl Ty {
         self.kind() == &TyKind::Unknown || self.kind() == &TyKind::Unbound
     }
 
+    pub(crate) fn is_unbound(&self) -> bool {
+        self.kind() == &TyKind::Unbound
+    }
+
+    pub(crate) fn is_possibly_unbound(&self) -> bool {
+        match self.kind() {
+            TyKind::Union(tys) => tys.iter().any(|ty| ty.is_possibly_unbound()),
+            TyKind::Unbound => true,
+            _ => false,
+        }
+    }
+
     pub(crate) fn substitute(&self, args: &[Ty]) -> Ty {
         match self.kind() {
             TyKind::List(ty) => Ty::list(ty.substitute(args)),
@@ -1561,7 +1573,7 @@ pub(crate) struct InferenceCtxt {
     pub(crate) type_of_load_item: FxHashMap<FileLoadItemId, Ty>,
     pub(crate) type_of_param: FxHashMap<FileParamId, Ty>,
     pub(crate) source_assign_done: FxHashSet<FileExprId>,
-    pub(crate) flow_node_type_cache: FxHashMap<CodeFlowCacheKey, Ty>,
+    pub(crate) flow_node_type_cache: FxHashMap<CodeFlowCacheKey, Option<Ty>>,
 }
 
 pub struct CancelGuard<'a> {

--- a/crates/starpls_hir/src/typeck.rs
+++ b/crates/starpls_hir/src/typeck.rs
@@ -144,7 +144,7 @@ impl std::error::Error for Cancelled {}
 
 #[derive(Clone, Debug, Default)]
 pub struct InferenceOptions {
-    pub infer_ctx_attrs: bool,
+    pub infer_ctx_attributes: bool,
     pub use_code_flow_analysis: bool,
 }
 

--- a/crates/starpls_hir/src/typeck.rs
+++ b/crates/starpls_hir/src/typeck.rs
@@ -565,6 +565,10 @@ impl Ty {
         TyKind::Any.intern()
     }
 
+    pub(crate) fn never() -> Ty {
+        TyKind::Never.intern()
+    }
+
     pub(crate) fn bool() -> Ty {
         TyKind::Bool(None).intern()
     }
@@ -606,12 +610,13 @@ impl Ty {
                 TyKind::Union(tys) => {
                     tys.iter().cloned().for_each(check_unique);
                 }
+                TyKind::Never => {}
                 _ => check_unique(ty),
             }
         }
 
         match unique_tys.len() {
-            0 => TyKind::Unknown.intern(),
+            0 => TyKind::Never.intern(),
             1 => unique_tys.into_iter().next().unwrap(),
             _ => TyKind::Union(unique_tys).intern(),
         }
@@ -1182,6 +1187,8 @@ pub(crate) enum TyKind {
     /// Similar to `Unknown`, but not necessarily the result of failed
     /// type inference.
     Any,
+    /// Indicates that the corresponding expression will never be evaluated.
+    Never,
     /// The type of the predefined `None` variable.
     None,
     /// A boolean.

--- a/crates/starpls_hir/src/typeck.rs
+++ b/crates/starpls_hir/src/typeck.rs
@@ -616,7 +616,7 @@ impl Ty {
         }
 
         match unique_tys.len() {
-            0 => TyKind::Never.intern(),
+            0 => Ty::never(),
             1 => unique_tys.into_iter().next().unwrap(),
             _ => TyKind::Union(unique_tys).intern(),
         }
@@ -1561,7 +1561,7 @@ pub(crate) struct InferenceCtxt {
     pub(crate) type_of_load_item: FxHashMap<FileLoadItemId, Ty>,
     pub(crate) type_of_param: FxHashMap<FileParamId, Ty>,
     pub(crate) source_assign_done: FxHashSet<FileExprId>,
-    pub(crate) flow_node_type_cache: FxHashMap<CodeFlowCacheKey, Option<Ty>>,
+    pub(crate) flow_node_type_cache: FxHashMap<CodeFlowCacheKey, Ty>,
 }
 
 pub struct CancelGuard<'a> {

--- a/crates/starpls_hir/src/typeck.rs
+++ b/crates/starpls_hir/src/typeck.rs
@@ -145,6 +145,7 @@ impl std::error::Error for Cancelled {}
 #[derive(Clone, Debug, Default)]
 pub struct InferenceOptions {
     pub infer_ctx_attrs: bool,
+    pub use_code_flow_analysis: bool,
 }
 
 #[derive(Default)]

--- a/crates/starpls_hir/src/typeck/infer.rs
+++ b/crates/starpls_hir/src/typeck/infer.rs
@@ -1175,6 +1175,7 @@ impl TyCtxt<'_> {
                         )
                     })))
                 }
+                FlowNode::Never { .. } => break Some(Ty::unknown()),
             }
         };
 

--- a/crates/starpls_hir/src/typeck/tests.rs
+++ b/crates/starpls_hir/src/typeck/tests.rs
@@ -1416,3 +1416,25 @@ def f():
         "#]],
     );
 }
+
+#[test]
+fn test_possibly_unbound() {
+    check_infer(
+        r#"
+def f():
+    if 1 < 2:
+        x = 1
+    x
+"#,
+        expect![[r#"
+            17..18 "1": Literal[1]
+            21..22 "2": Literal[2]
+            17..22 "1 < 2": bool
+            32..33 "x": Literal[1]
+            36..37 "1": Literal[1]
+            42..43 "x": int | Unbound
+
+            42..43 "x" is possibly unbound
+        "#]],
+    )
+}

--- a/crates/starpls_ide/src/goto_definition.rs
+++ b/crates/starpls_ide/src/goto_definition.rs
@@ -28,7 +28,7 @@ pub(crate) fn goto_definition(
             sema.scope_for_expr(file, &ast::Expression::cast(name_ref.syntax().clone())?)?;
         return Some(
             scope
-                .resolve_name(&name)?
+                .resolve_name(&name)
                 .into_iter()
                 .flat_map(|def| match def {
                     ScopeDef::LoadItem(load_item) => {

--- a/crates/starpls_parser/src/grammar/type_comments.rs
+++ b/crates/starpls_parser/src/grammar/type_comments.rs
@@ -53,6 +53,10 @@ pub(crate) fn parameter_type(p: &mut Parser) {
             union_type(p);
             m.complete(p, KWARGS_DICT_PARAMETER_TYPE);
         }
+        ELLIPSIS => {
+            p.bump(ELLIPSIS);
+            m.complete(p, SIMPLE_PARAMETER_TYPE);
+        }
         _ => unreachable!(),
     }
 }


### PR DESCRIPTION
Currently, the type inference mechanism is very simple in that in infers types for a variable based only on the last seen assignment to the variable. This has shortcomings for scenarios like the following, where the type may differ based on the branch taken.

```python
x = ""

if y == 0:
    x = True

x # inferred as `Literal[True]`, should be `Literal[""] | True`
```

To make the type checker more accurate in these situations, this PR introduces a primitive form of data-flow analysis heavily based on Pyright and, by extension, the TypeScript compiler. This includes constructing a code-flow graph as an additional lowering step and using it to determine types as part of the type checker. While under active development, this functionality will be gated behind the `--experimental_use_code_flow_analysis` flag.

Tasks:
- [ ] Support constructing a code-flow graph from the current HIR
  - [x] `if` statements
  - [x] `for` loops
  - [x] List/dict comprehensions
  - [ ] Assignments for params (will do in follow-up)
- [ ] Use code-flow graph as part of type inference
  - [x] `if` statements
  - [x] `for` loops
- [ ] Caching mechanism data-flow analysis results
  - [ ] Effective type results (will do in follow-up)
  - [x] Type of reference at specific flow nodes
- [x] Add `--experimental_use_code_flow_analysis` flag