### PR TITLE
Support `LocationLink`

### DIFF
--- a/crates/starpls/src/config.rs
+++ b/crates/starpls/src/config.rs
@@ -1,0 +1,21 @@
+use lsp_types::ClientCapabilities;
+
+pub(crate) struct ServerConfig {
+    caps: ClientCapabilities,
+}
+
+macro_rules! try_or_default {
+    ($expr:expr) => {
+        (|| $expr)().unwrap_or_default()
+    };
+}
+
+impl ServerConfig {
+    pub(crate) fn new(caps: ClientCapabilities) -> Self {
+        Self { caps }
+    }
+
+    pub(crate) fn has_text_document_definition_link_support(&self) -> bool {
+        try_or_default!(self.caps.text_document.as_ref()?.definition?.link_support)
+    }
+}

--- a/crates/starpls/src/event_loop.rs
+++ b/crates/starpls/src/event_loop.rs
@@ -1,4 +1,5 @@
 use crate::{
+    config::ServerConfig,
     convert,
     dispatcher::RequestDispatcher,
     document::DocumentSource,
@@ -52,10 +53,11 @@ pub(crate) enum Event {
 
 pub fn process_connection(
     connection: Connection,
-    _initialize_params: InitializeParams,
+    initialize_params: InitializeParams,
 ) -> anyhow::Result<()> {
     eprintln!("server: initializing state and starting event loop");
-    let server = Server::new(connection)?;
+    let config = ServerConfig::new(initialize_params.capabilities);
+    let server = Server::new(connection, config)?;
     server.run()
 }
 

--- a/crates/starpls/src/main.rs
+++ b/crates/starpls/src/main.rs
@@ -7,6 +7,7 @@ use lsp_types::{
 };
 
 mod check;
+mod config;
 mod convert;
 mod debouncer;
 mod diagnostics;
@@ -50,7 +51,7 @@ fn main() -> anyhow::Result<()> {
 }
 
 fn run_server() -> anyhow::Result<()> {
-    eprintln!("server: starpls, v0.1.11");
+    eprintln!("server: starpls, v0.1.12");
 
     // Create the transport over stdio.
     let (connection, io_threads) = Connection::stdio();

--- a/crates/starpls_ide/src/lib.rs
+++ b/crates/starpls_ide/src/lib.rs
@@ -297,7 +297,7 @@ impl AnalysisSnapshot {
         self.query(|db| diagnostics::diagnostics(db, file_id))
     }
 
-    pub fn goto_definition(&self, pos: FilePosition) -> Cancellable<Option<Vec<Location>>> {
+    pub fn goto_definition(&self, pos: FilePosition) -> Cancellable<Option<Vec<LocationLink>>> {
         self.query(|db| {
             let res = goto_definition::goto_definition(db, pos);
             res
@@ -336,9 +336,17 @@ impl AnalysisSnapshot {
 impl panic::RefUnwindSafe for AnalysisSnapshot {}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum Location {
-    Local { file_id: FileId, range: TextRange },
-    External { path: PathBuf },
+pub enum LocationLink {
+    Local {
+        origin_selection_range: Option<TextRange>,
+        target_range: TextRange,
+        target_selection_range: TextRange,
+        target_file_id: FileId,
+    },
+    External {
+        origin_selection_range: Option<TextRange>,
+        target_path: PathBuf,
+    },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
Adds support for `LocationLink`, which is now used by default if `textDocument.declaration.linkSupport` is set.