### PR TITLE
Fetch external repositories on demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ then you'll get autocomplete suggestions for the attributes on `ctx`, like `ctx.
         - [x] Relative paths
         - [x] Bazel workspace
     - [x] Bazel external repositories
+    - [ ] Nested local repositories
 
 ## Development
 

--- a/crates/starpls/src/check.rs
+++ b/crates/starpls/src/check.rs
@@ -32,6 +32,7 @@ pub(crate) fn run_check(paths: Vec<String>, output_base: Option<String>) -> anyh
             }
         };
 
+    let (fetch_repo_sender, _) = crossbeam_channel::unbounded();
     let builtins = load_bazel_builtins()?;
     let rules = load_bazel_build_language(&*bazel_client)?;
     let interner = Arc::new(PathInterner::default());
@@ -40,6 +41,7 @@ pub(crate) fn run_check(paths: Vec<String>, output_base: Option<String>) -> anyh
         interner.clone(),
         info.workspace,
         external_output_base,
+        fetch_repo_sender,
         bzlmod_enabled,
     );
     let mut analysis = Analysis::new(Arc::new(loader));

--- a/crates/starpls/src/document.rs
+++ b/crates/starpls/src/document.rs
@@ -1,3 +1,4 @@
+use crate::event_loop::FetchExternalRepoRequest;
 use anyhow::{anyhow, bail, Ok};
 use crossbeam_channel::Sender;
 use dashmap::DashMap;
@@ -168,7 +169,7 @@ pub(crate) struct DefaultFileLoader {
     workspace: PathBuf,
     external_output_base: PathBuf,
     cached_load_results: DashMap<String, PathBuf>,
-    fetch_repo_sender: Sender<String>,
+    fetch_repo_sender: Sender<FetchExternalRepoRequest>,
     bzlmod_enabled: bool,
 }
 
@@ -178,7 +179,7 @@ impl DefaultFileLoader {
         interner: Arc<PathInterner>,
         workspace: PathBuf,
         external_output_base: PathBuf,
-        fetch_repo_sender: Sender<String>,
+        fetch_repo_sender: Sender<FetchExternalRepoRequest>,
         bzlmod_enabled: bool,
     ) -> Self {
         Self {
@@ -382,7 +383,10 @@ impl FileLoader for DefaultFileLoader {
                                 .ok()
                                 .unwrap_or_default()
                             {
-                                let _ = self.fetch_repo_sender.send(canonical_repo);
+                                let _ = self.fetch_repo_sender.send(FetchExternalRepoRequest {
+                                    file_id: from,
+                                    repo: canonical_repo,
+                                });
                             }
                         }
 

--- a/crates/starpls/src/document.rs
+++ b/crates/starpls/src/document.rs
@@ -267,6 +267,9 @@ impl DefaultFileLoader {
                 }
             }
             RepoKind::Canonical | RepoKind::Apparent => {
+                if !label.repo().is_empty() {
+                    canonical_repo_res = Some(label.repo().to_string());
+                }
                 (self.external_output_base.join(label.repo()), PathBuf::new())
             }
             RepoKind::Current => {
@@ -371,10 +374,6 @@ impl FileLoader for DefaultFileLoader {
                 let contents = match fs::read_to_string(&path) {
                     Result::Ok(contents) => contents,
                     Err(err) => {
-                        eprintln!(
-                            "failed to read, checking canonical repo: {:?}",
-                            canonical_repo
-                        );
                         if let Some(canonical_repo) = canonical_repo {
                             if !self
                                 .external_output_base
@@ -383,7 +382,6 @@ impl FileLoader for DefaultFileLoader {
                                 .ok()
                                 .unwrap_or_default()
                             {
-                                eprintln!("fetching");
                                 let _ = self.fetch_repo_sender.send(canonical_repo);
                             }
                         }

--- a/crates/starpls/src/document.rs
+++ b/crates/starpls/src/document.rs
@@ -1,4 +1,4 @@
-use crate::event_loop::FetchExternalRepoRequest;
+use crate::event_loop::{FetchExternalRepoRequest, Task};
 use anyhow::{anyhow, bail, Ok};
 use crossbeam_channel::Sender;
 use dashmap::DashMap;
@@ -169,7 +169,7 @@ pub(crate) struct DefaultFileLoader {
     workspace: PathBuf,
     external_output_base: PathBuf,
     cached_load_results: DashMap<String, PathBuf>,
-    fetch_repo_sender: Sender<FetchExternalRepoRequest>,
+    fetch_repo_sender: Sender<Task>,
     bzlmod_enabled: bool,
 }
 
@@ -179,7 +179,7 @@ impl DefaultFileLoader {
         interner: Arc<PathInterner>,
         workspace: PathBuf,
         external_output_base: PathBuf,
-        fetch_repo_sender: Sender<FetchExternalRepoRequest>,
+        fetch_repo_sender: Sender<Task>,
         bzlmod_enabled: bool,
     ) -> Self {
         Self {
@@ -383,10 +383,12 @@ impl FileLoader for DefaultFileLoader {
                                 .ok()
                                 .unwrap_or_default()
                             {
-                                let _ = self.fetch_repo_sender.send(FetchExternalRepoRequest {
-                                    file_id: from,
-                                    repo: canonical_repo,
-                                });
+                                let _ = self.fetch_repo_sender.send(
+                                    Task::FetchExternalRepoRequest(FetchExternalRepoRequest {
+                                        file_id: from,
+                                        repo: canonical_repo,
+                                    }),
+                                );
                             }
                         }
 

--- a/crates/starpls/src/event_loop.rs
+++ b/crates/starpls/src/event_loop.rs
@@ -208,6 +208,7 @@ impl Server {
                 if lsp_types::notification::DidOpenTextDocument as params => notifications::did_open_text_document(self, params),
                 if lsp_types::notification::DidCloseTextDocument as params => notifications::did_close_text_document(self, params),
                 if lsp_types::notification::DidChangeTextDocument as params => notifications::did_change_text_document(self, params),
+                if lsp_types::notification::DidSaveTextDocument as params => notifications::did_save_text_document(self, params),
                 _ => Ok(())
             }
         }

--- a/crates/starpls/src/event_loop.rs
+++ b/crates/starpls/src/event_loop.rs
@@ -100,6 +100,10 @@ impl Server {
             Event::Task(task) => self.handle_task(task),
         };
 
+        if !self.pending_repos.is_empty() && !self.is_fetching_repos {
+            self.fetch_bazel_external_repos();
+        }
+
         // Update our diagnostics if a triggering event (e.g. document open/close/change) occured.
         // This is done asynchronously, so any new diagnostics resulting from this won't be seen until the next turn
         // of the event loop.
@@ -253,7 +257,6 @@ impl Server {
             Task::FetchExternalRepoRequest(repo) => {
                 if !self.fetched_repos.contains(&repo) {
                     self.pending_repos.insert(repo);
-                    self.fetch_bazel_external_repos();
                 }
             }
         }

--- a/crates/starpls_bazel/src/client.rs
+++ b/crates/starpls_bazel/src/client.rs
@@ -4,7 +4,7 @@ use serde_json::Deserializer;
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
-    process::Command,
+    process::{Command, Stdio},
     str,
 };
 
@@ -24,6 +24,7 @@ pub trait BazelClient: Send + Sync + 'static {
         apparent_repo: &str,
         from_repo: &str,
     ) -> anyhow::Result<Option<String>>;
+    fn null_query_external_repo_targets(&self, repo: &str) -> anyhow::Result<()>;
 }
 
 pub struct BazelCLI {
@@ -122,6 +123,15 @@ impl BazelClient for BazelCLI {
             .write()
             .insert(from_repo.to_string(), mapping);
         Ok(canonical_repo)
+    }
+
+    fn null_query_external_repo_targets(&self, repo: &str) -> anyhow::Result<()> {
+        Command::new(&self.executable)
+            .args(["query", "--keep_going", &format!("@@{}//...", repo)])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()?;
+        Ok(())
     }
 }
 

--- a/crates/starpls_bazel/src/client.rs
+++ b/crates/starpls_bazel/src/client.rs
@@ -24,6 +24,7 @@ pub trait BazelClient: Send + Sync + 'static {
         apparent_repo: &str,
         from_repo: &str,
     ) -> anyhow::Result<Option<String>>;
+    fn clear_repo_mappings(&self);
     fn null_query_external_repo_targets(&self, repo: &str) -> anyhow::Result<()>;
 }
 
@@ -123,6 +124,10 @@ impl BazelClient for BazelCLI {
             .write()
             .insert(from_repo.to_string(), mapping);
         Ok(canonical_repo)
+    }
+
+    fn clear_repo_mappings(&self) {
+        self.repo_mappings.write().clear();
     }
 
     fn null_query_external_repo_targets(&self, repo: &str) -> anyhow::Result<()> {

--- a/crates/starpls_ide/src/goto_definition.rs
+++ b/crates/starpls_ide/src/goto_definition.rs
@@ -3,7 +3,7 @@ use starpls_common::{parse, Db, File, InFile};
 use starpls_hir::{LoadItem, Name, ScopeDef, Semantics};
 use starpls_syntax::{
     ast::{self, AstNode},
-    TextRange, TextSize, T,
+    T,
 };
 
 pub(crate) fn goto_definition(

--- a/crates/starpls_ide/src/lib.rs
+++ b/crates/starpls_ide/src/lib.rs
@@ -355,6 +355,16 @@ pub struct FilePosition {
     pub pos: TextSize,
 }
 
+pub enum ResolvedPath {
+    Source {
+        path: PathBuf,
+    },
+    BuildTarget {
+        build_file_path: PathBuf,
+        target: String,
+    },
+}
+
 /// A trait for loading a path and listing its exported symbols.
 pub trait FileLoader: Send + Sync + 'static {
     fn resolve_path(

--- a/crates/starpls_parser/src/grammar/statements.rs
+++ b/crates/starpls_parser/src/grammar/statements.rs
@@ -91,7 +91,7 @@ pub(crate) fn def_stmt(p: &mut Parser) {
 
 /// Parses an `if` statement.
 ///
-/// Gramar: `IfStmt = 'if' Test ':' Suite {'elif' Test ':' Suite} ['else' ':' Suite] .`
+/// Grammar: `IfStmt = 'if' Test ':' Suite {'elif' Test ':' Suite} ['else' ':' Suite] .`
 pub(crate) fn if_stmt(p: &mut Parser, if_or_elif: SyntaxKind) {
     let m = p.start();
     p.bump(if_or_elif);


### PR DESCRIPTION
Fixes: https://github.com/withered-magic/starpls/issues/195

This PR adds functionality for fetching external repositories on demand. For example, if the LSP sees a load statement like

```python
load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
```

but the `rules_rust` repository hasn't been fetched yet, the LSP will go ahead and fetch it with a Bazel query:

```sh
bazel query --keep_going @@rules_rust/...
```

Tasks:
- [x] Support `WORKSPACE.bazel`
- [x] Support `bzlmod`
- [x] Automatically update diagnostics for affected files once repositories have been fetched
- [x] Invalidate `fetched_repos` cache on `MODULE.bazel`/`WORKSPACE` changes.