### PR TITLE
Resolve non-source file labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ then you'll get autocomplete suggestions for the attributes on `ctx`, like `ctx.
     - [x] Function definitions
     - [x] Struct fields
     - [x] Provider fields
-    - [x] Labels in `load` statements
+    - [x] Labels and targets
     - [ ] Rule attributes
 - Type inference
     - [x] Basic type inference

--- a/crates/starpls/src/document.rs
+++ b/crates/starpls/src/document.rs
@@ -325,7 +325,11 @@ impl FileLoader for DefaultFileLoader {
             None => return Ok(None),
         };
 
-        let res = if resolved_path.try_exists().unwrap_or_default() {
+        let res = if fs::metadata(&resolved_path)
+            .ok()
+            .map(|metadata| metadata.is_file())
+            .unwrap_or_default()
+        {
             ResolvedPath::Source {
                 path: resolved_path,
             }

--- a/crates/starpls/src/document.rs
+++ b/crates/starpls/src/document.rs
@@ -253,7 +253,6 @@ impl DefaultFileLoader {
                 let canonical_repo = self
                     .bazel_client
                     .resolve_repo_from_mapping(label.repo(), from_repo)?;
-
                 match canonical_repo {
                     Some(canonical_repo) => (
                         if canonical_repo.is_empty() {
@@ -264,7 +263,16 @@ impl DefaultFileLoader {
                         },
                         PathBuf::new(),
                     ),
-                    None => return Ok(None),
+                    None => {
+                        bail!(
+                            "Could not resolve repository \"{}{}\" from current repository mapping",
+                            match label.kind() {
+                                RepoKind::Canonical => "@@",
+                                _ => "@",
+                            },
+                            label.repo()
+                        )
+                    }
                 }
             }
             RepoKind::Canonical | RepoKind::Apparent => {
@@ -464,7 +472,6 @@ impl FileLoader for DefaultFileLoader {
                 let from_dir = self.dirname(from);
                 let has_trailing_slash = path.ends_with(MAIN_SEPARATOR);
                 let mut path = from_dir.join(path);
-
                 if !has_trailing_slash {
                     if !path.pop() {
                         return Ok(None);

--- a/crates/starpls/src/server.rs
+++ b/crates/starpls/src/server.rs
@@ -60,6 +60,8 @@ impl Server {
             }
         };
 
+        eprintln!("server: fetching Bazel configuration");
+
         let bazel_client = Arc::new(BazelCLI::default());
         let info = bazel_client.info().unwrap_or_default();
 

--- a/crates/starpls_bazel/src/label.rs
+++ b/crates/starpls_bazel/src/label.rs
@@ -230,6 +230,11 @@ impl<'a, 'b> Parser<'a, 'b> {
         if has_target_only_chars {
             return Err(ParseError::InvalidPackage);
         }
+        if let Some(last_slash) = last_slash {
+            if last_slash + 1 == end {
+                return Err(ParseError::InvalidPackage);
+            }
+        }
         self.label.package_start = start;
         self.label.package_end = end;
         Ok(last_slash)
@@ -469,5 +474,10 @@ mod tests {
     #[test]
     fn test_missing_package() {
         check_err("@a//", ParseError::EmptyPackage);
+    }
+
+    #[test]
+    fn test_invalid_package_ends_with_slash() {
+        check_err("@a//abc/", ParseError::InvalidPackage);
     }
 }

--- a/crates/starpls_bazel/src/label.rs
+++ b/crates/starpls_bazel/src/label.rs
@@ -167,11 +167,13 @@ impl<'a, 'b> Parser<'a, 'b> {
             assert_eq!(self.bump(), Some(':'));
         } else if self.pos == 0 {
         } else {
-            self.parse_package()?;
+            let last_slash = self.parse_package()?;
             return if self.label.package_start == self.label.package_end {
                 Err(ParseError::EmptyPackage)
             } else {
-                self.label.target_start = self.label.package_start;
+                self.label.target_start = last_slash
+                    .map(|pos| pos + 1)
+                    .unwrap_or(self.label.package_start);
                 self.label.target_end = self.label.package_end;
                 Ok(())
             };
@@ -219,21 +221,22 @@ impl<'a, 'b> Parser<'a, 'b> {
         Ok(())
     }
 
-    fn parse_package(&mut self) -> Result<(), ParseError> {
-        let (start, end, has_target_only_chars) = match self.parse_package_or_target(true) {
-            Ok(res) => res,
-            Err(_) => return Err(ParseError::InvalidPackage),
-        };
+    fn parse_package(&mut self) -> Result<Option<u32>, ParseError> {
+        let (start, end, last_slash, has_target_only_chars) =
+            match self.parse_package_or_target(true) {
+                Ok(res) => res,
+                Err(_) => return Err(ParseError::InvalidPackage),
+            };
         if has_target_only_chars {
             return Err(ParseError::InvalidPackage);
         }
         self.label.package_start = start;
         self.label.package_end = end;
-        Ok(())
+        Ok(last_slash)
     }
 
     fn parse_target(&mut self) -> Result<(), ParseError> {
-        let (start, end, _) = match self.parse_package_or_target(false) {
+        let (start, end, _, _) = match self.parse_package_or_target(false) {
             Ok(res) => res,
             Err(_) => return Err(ParseError::InvalidTarget),
         };
@@ -245,12 +248,20 @@ impl<'a, 'b> Parser<'a, 'b> {
         Ok(())
     }
 
-    fn parse_package_or_target(&mut self, allow_colon: bool) -> Result<(u32, u32, bool), ()> {
+    fn parse_package_or_target(
+        &mut self,
+        allow_colon: bool,
+    ) -> Result<(u32, u32, Option<u32>, bool), ()> {
         let start = self.pos;
         let mut has_target_only_chars = false;
+        let mut last_slash = None;
         while let Some(c) = self.first() {
             match c {
-                'A'..='Z' | 'a'..='z' | '0'..='9' | '/' | '-' | '.' | '@' | '_' => {
+                '/' => {
+                    last_slash = Some(self.pos);
+                    self.bump();
+                }
+                'A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '.' | '@' | '_' => {
                     self.bump();
                 }
                 '!' | '%' | '^' | '"' | '#' | '$' | '&' | '\'' | '(' | ')' | '*' | '+' | ','
@@ -262,7 +273,7 @@ impl<'a, 'b> Parser<'a, 'b> {
                 _ => return Err(()),
             }
         }
-        Ok((start, self.pos, has_target_only_chars))
+        Ok((start, self.pos, last_slash, has_target_only_chars))
     }
 
     fn bump(&mut self) -> Option<char> {
@@ -329,7 +340,15 @@ mod tests {
 
     #[test]
     fn test_implicit_target() {
-        check("//a", Current, false, "", "a", "a")
+        check("//a", Current, false, "", "a", "a");
+        check(
+            "//crates/starpls_bazel",
+            Current,
+            false,
+            "",
+            "crates/starpls_bazel",
+            "starpls_bazel",
+        )
     }
 
     #[test]

--- a/crates/starpls_hir/src/test_database.rs
+++ b/crates/starpls_hir/src/test_database.rs
@@ -1,9 +1,9 @@
 use crate::{def::ExprId, BuiltinDefs, Db, Dialect, GlobalCtxt, LoadItemId, ParamId, Ty};
 use dashmap::{mapref::entry::Entry, DashMap};
 use starpls_bazel::{APIContext, Builtins};
-use starpls_common::{File, FileId, LoadItemCandidate};
+use starpls_common::{File, FileId, LoadItemCandidate, ResolvedPath};
 use starpls_test_util::builtins_with_catch_all_functions;
-use std::sync::Arc;
+use std::{any, sync::Arc};
 
 #[derive(Default)]
 #[salsa::db(starpls_common::Jar, crate::Jar)]
@@ -82,6 +82,15 @@ impl starpls_common::Db for TestDatabase {
         _path: &str,
         _from: FileId,
     ) -> anyhow::Result<Option<Vec<LoadItemCandidate>>> {
+        Ok(None)
+    }
+
+    fn resolve_path(
+        &self,
+        _path: &str,
+        _dialect: Dialect,
+        _from: FileId,
+    ) -> anyhow::Result<Option<ResolvedPath>> {
         Ok(None)
     }
 }

--- a/crates/starpls_hir/src/test_database.rs
+++ b/crates/starpls_hir/src/test_database.rs
@@ -3,7 +3,7 @@ use dashmap::{mapref::entry::Entry, DashMap};
 use starpls_bazel::{APIContext, Builtins};
 use starpls_common::{File, FileId, LoadItemCandidate, ResolvedPath};
 use starpls_test_util::builtins_with_catch_all_functions;
-use std::{any, sync::Arc};
+use std::sync::Arc;
 
 #[derive(Default)]
 #[salsa::db(starpls_common::Jar, crate::Jar)]

--- a/crates/starpls_ide/src/goto_definition.rs
+++ b/crates/starpls_ide/src/goto_definition.rs
@@ -153,41 +153,35 @@ pub(crate) fn goto_definition(
             } => {
                 let build_file = db.get_file(build_file_id)?;
                 let parse = parse_query(db, build_file).syntax(db);
-                let target_name_range =
-                    parse
-                        .children()
-                        .filter_map(ast::CallExpr::cast)
-                        .find_map(|expr| {
-                            expr.arguments()
-                                .into_iter()
-                                .flat_map(|args| args.arguments())
-                                .find_map(|arg| match arg {
-                                    ast::Argument::Keyword(arg) => arg
-                                        .expr()
-                                        .and_then(|expr| match expr {
-                                            ast::Expression::Literal(expr) => Some(expr),
-                                            _ => None,
-                                        })
-                                        .and_then(|expr| match expr.kind() {
-                                            ast::LiteralKind::String(s) => s
-                                                .value()
-                                                .map(|value| (expr.syntax().text_range(), value)),
-                                            _ => None,
-                                        })
-                                        .and_then(|(range, value)| {
-                                            if target == &*value {
-                                                Some(range)
-                                            } else {
-                                                None
-                                            }
-                                        }),
-                                    _ => None,
-                                })
-                        })?;
+                let call_expr = parse
+                    .children()
+                    .filter_map(ast::CallExpr::cast)
+                    .find(|expr| {
+                        expr.arguments()
+                            .into_iter()
+                            .flat_map(|args| args.arguments())
+                            .any(|arg| match arg {
+                                ast::Argument::Keyword(arg) => arg
+                                    .expr()
+                                    .and_then(|expr| match expr {
+                                        ast::Expression::Literal(expr) => Some(expr),
+                                        _ => None,
+                                    })
+                                    .and_then(|expr| match expr.kind() {
+                                        ast::LiteralKind::String(s) => {
+                                            s.value().map(|value| &*value == target)
+                                        }
+                                        _ => None,
+                                    })
+                                    .unwrap_or_default(),
+                                _ => false,
+                            })
+                    })?;
+                let range = call_expr.syntax().text_range();
                 Some(vec![LocationLink::Local {
                     origin_selection_range: Some(token.text_range()),
-                    target_range: target_name_range.clone(),
-                    target_selection_range: target_name_range,
+                    target_range: range.clone(),
+                    target_selection_range: range,
                     target_file_id: build_file_id,
                 }])
             }

--- a/crates/starpls_ide/src/lib.rs
+++ b/crates/starpls_ide/src/lib.rs
@@ -148,7 +148,7 @@ impl starpls_common::Db for Database {
         {
             match self.files.entry(build_file) {
                 Entry::Vacant(entry) => {
-                    *entry.insert(File::new(
+                    entry.insert(File::new(
                         self,
                         build_file,
                         Dialect::Bazel,


### PR DESCRIPTION
Fixes: https://github.com/withered-magic/starpls/issues/203

This PR adds Go to Definition functionality for non-source-file targets, e.g. `//crates/starpls`. This works by finding the first function call with a `name` argument, a heuristic also used by `starlark-rust` and `bazel-lsp`.

TODO:
- [x] Cleanup docs
- [x] Identify refactoring opportunities
- [x] Verify behavior for `BUILD` files, e.g. already opened vs not