### PR TITLE
allow specifying bazel binary

### DIFF
--- a/crates/starpls/src/config.rs
+++ b/crates/starpls/src/config.rs
@@ -1,7 +1,10 @@
+use crate::ServerArgs;
 use lsp_types::ClientCapabilities;
 
+#[derive(Default)]
 pub(crate) struct ServerConfig {
-    caps: ClientCapabilities,
+    pub(crate) args: ServerArgs,
+    pub(crate) caps: ClientCapabilities,
 }
 
 macro_rules! try_or_default {
@@ -11,10 +14,6 @@ macro_rules! try_or_default {
 }
 
 impl ServerConfig {
-    pub(crate) fn new(caps: ClientCapabilities) -> Self {
-        Self { caps }
-    }
-
     pub(crate) fn has_text_document_definition_link_support(&self) -> bool {
         try_or_default!(self.caps.text_document.as_ref()?.definition?.link_support)
     }

--- a/crates/starpls/src/event_loop.rs
+++ b/crates/starpls/src/event_loop.rs
@@ -6,6 +6,7 @@ use crate::{
     extensions,
     handlers::{notifications, requests},
     server::{Server, ServerSnapshot},
+    ServerArgs,
 };
 use crossbeam_channel::select;
 use lsp_server::Connection;
@@ -61,10 +62,14 @@ pub(crate) enum Event {
 
 pub fn process_connection(
     connection: Connection,
+    args: ServerArgs,
     initialize_params: InitializeParams,
 ) -> anyhow::Result<()> {
     eprintln!("server: initializing state and starting event loop");
-    let config = ServerConfig::new(initialize_params.capabilities);
+    let config = ServerConfig {
+        args,
+        caps: initialize_params.capabilities,
+    };
     let server = Server::new(connection, config)?;
     server.run()
 }

--- a/crates/starpls/src/server.rs
+++ b/crates/starpls/src/server.rs
@@ -62,7 +62,15 @@ impl Server {
 
         eprintln!("server: fetching Bazel configuration");
 
-        let bazel_client = Arc::new(BazelCLI::default());
+        let bazel_path = config
+            .args
+            .bazel_path
+            .clone()
+            .unwrap_or("bazel".to_string());
+
+        eprintln!("server: using Bazel executable at {:?}", bazel_path);
+
+        let bazel_client = Arc::new(BazelCLI::new(&bazel_path));
         let info = bazel_client.info().unwrap_or_default();
 
         eprintln!("server: workspace root: {:?}", info.workspace);


### PR DESCRIPTION
Adds the `--bazel_path` flag to the `starpls server` command, allowing a user to specify a path to the Bazel binary instead of automatically using the one on the `$PATH`.