### PR TITLE
add `Struct::FieldSignature`

### DIFF
--- a/crates/starpls_hir/src/api.rs
+++ b/crates/starpls_hir/src/api.rs
@@ -7,8 +7,8 @@ use crate::{
     },
     module, source_map,
     typeck::{
-        builtins::BuiltinFunction, intrinsics::IntrinsicFunction, resolve_type_ref, ParamInner,
-        Provider, Substitution, TagClass, Tuple, Ty, TypeRef,
+        self, builtins::BuiltinFunction, intrinsics::IntrinsicFunction, resolve_type_ref,
+        ParamInner, Provider, Substitution, TagClass, Tuple, Ty, TypeRef,
     },
     Db, ExprId, Name, TyKind,
 };
@@ -382,10 +382,13 @@ impl Type {
         }
     }
 
-    pub fn try_as_struct(&self) -> Option<Struct> {
+    pub fn try_as_inline_struct(&self) -> Option<Struct> {
         match self.ty.kind() {
-            TyKind::Struct(struct_) => struct_.as_ref().map(|struct_| Struct {
-                call_expr: struct_.call_expr.clone(),
+            TyKind::Struct(strukt) => strukt.as_ref().and_then(|strukt| match strukt {
+                &typeck::Struct::Inline { ref call_expr, .. } => Some(Struct {
+                    call_expr: call_expr.clone(),
+                }),
+                _ => None,
             }),
             _ => None,
         }

--- a/crates/starpls_hir/src/typeck/infer.rs
+++ b/crates/starpls_hir/src/typeck/infer.rs
@@ -12,8 +12,8 @@ use crate::{
         call::{Slot, SlotProvider, Slots},
         intrinsics::{IntrinsicFunctionParam, IntrinsicTypes},
         resolve_type_ref, resolve_type_ref_opt, DictLiteral, FileExprId, FileLoadItemId,
-        FileLoadStmt, FileParamId, Protocol, Substitution, Tuple, Ty, TyCtxt, TyKind, TypeRef,
-        TypecheckCancelled,
+        FileLoadStmt, FileParamId, Protocol, Struct, Substitution, Tuple, Ty, TyCtxt, TyKind,
+        TypeRef, TypecheckCancelled,
     },
     Name,
 };
@@ -235,8 +235,12 @@ impl TyCtxt<'_> {
                         })
                     })
                     .unwrap_or_else(|| {
-                        if matches!(receiver_ty.kind(), TyKind::Struct(_)) {
-                            return self.unknown_ty();
+                        match receiver_ty.kind() {
+                            TyKind::Struct(Some(Struct::FieldSignature { ty })) => {
+                                return ty.clone()
+                            }
+                            TyKind::Struct(_) => return self.unknown_ty(),
+                            _ => {}
                         }
 
                         self.add_expr_diagnostic_warning_ty(

--- a/crates/starpls_ide/src/goto_definition.rs
+++ b/crates/starpls_ide/src/goto_definition.rs
@@ -58,8 +58,8 @@ pub(crate) fn goto_definition(
         let ty = sema.type_of_expr(file, &dot_expr.expr()?)?;
 
         // Check for struct field definition.
-        if let Some(struct_) = ty.try_as_struct() {
-            let struct_call_expr = struct_.call_expr(db)?;
+        if let Some(strukt) = ty.try_as_inline_struct() {
+            let struct_call_expr = strukt.call_expr(db)?;
             return struct_call_expr
                 .value
                 .arguments()

--- a/crates/starpls_ide/src/lib.rs
+++ b/crates/starpls_ide/src/lib.rs
@@ -5,7 +5,7 @@ use starpls_bazel::{APIContext, Builtins};
 use starpls_common::{Db, Diagnostic, Dialect, File, FileId, LoadItemCandidate, ResolvedPath};
 use starpls_hir::{BuiltinDefs, Db as _, ExprId, GlobalCtxt, LoadItemId, LoadStmt, ParamId, Ty};
 use starpls_syntax::{LineIndex, TextRange, TextSize};
-use starpls_test_util::builtins_with_catch_all_functions;
+use starpls_test_util::make_test_builtins;
 use std::{fmt::Debug, panic, path::PathBuf, sync::Arc};
 
 pub use crate::{
@@ -313,7 +313,7 @@ impl AnalysisSnapshot {
         let mut analysis = Analysis::new(Arc::new(SimpleFileLoader::from_file_set(file_set)));
         analysis.db.set_builtin_defs(
             Dialect::Bazel,
-            builtins_with_catch_all_functions(&["provider", "struct"]),
+            make_test_builtins(vec!["provider".to_string(), "struct".to_string()], vec![]),
             Builtins::default(),
         );
         analysis.apply_change(change);

--- a/crates/starpls_test_util/src/lib.rs
+++ b/crates/starpls_test_util/src/lib.rs
@@ -1,5 +1,5 @@
 use starpls_bazel::{
-    builtin::{Callable, Param, Value},
+    builtin::{Callable, Param, Type, Value},
     Builtins,
 };
 use starpls_syntax::{TextRange, TextSize};
@@ -33,9 +33,16 @@ fn find_selected_ranges(contents: &str) -> Vec<TextRange> {
     }
     ranges
 }
-pub fn builtins_with_catch_all_functions(names: &[&str]) -> Builtins {
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct FixtureType {
+    pub name: String,
+    pub fields: Vec<(String, String)>,
+}
+
+pub fn make_test_builtins(functions: Vec<String>, types: Vec<FixtureType>) -> Builtins {
     Builtins {
-        global: names
+        global: functions
             .iter()
             .map(|name| Value {
                 name: name.to_string(),
@@ -57,6 +64,21 @@ pub fn builtins_with_catch_all_functions(names: &[&str]) -> Builtins {
                 ..Default::default()
             })
             .collect(),
-        ..Default::default()
+        r#type: types
+            .into_iter()
+            .map(|ty| Type {
+                name: ty.name,
+                field: ty
+                    .fields
+                    .into_iter()
+                    .map(|field| Value {
+                        name: field.0,
+                        r#type: field.1,
+                        ..Default::default()
+                    })
+                    .collect(),
+                ..Default::default()
+            })
+            .collect(),
     }
 }


### PR DESCRIPTION
Discussed in: https://github.com/withered-magic/starpls/issues/224

Adds support for "field signature structs", which function similarly to TypeScript's [index signatures](https://www.typescriptlang.org/docs/handbook/2/objects.html#index-signatures) and allow prescribing types to unknown struct fields. Currently, the only expressions that use these are `ctx.executable`, `ctx.file`, `ctx.files`, and `ctx.executable`.

For example:

```python
def _impl(ctx):
    # type: (ctx) -> Unknown
    tpl = ctx.file.tpl # inferred as File
```