### PR TITLE
Infer `ctx` attributes from usage in `rule` or `repository_rule` invocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,17 @@ Once done, add the following to your VSCode configuration and reload VSCode for 
 }
 ```
 
+Experimental features are enabled through flags on the `starpls server` subcommand. For example:
+
+```jsonc
+{
+    "bazel.lsp.command": "starpls",
+    // Note the first argument is "server", which is required because the flags exist only
+    // on the "starpls server" subcommand (and not the top-level "starpls" command).
+    "bazel.lsp.args": ["server", "--experimental_infer_ctx_attributes"]
+}
+```
+
 Note: If you don't put `starpls` directly on the `$PATH`, then for `bazel.lsp.command` you'll have to specify the absolute path to the `starpls` executable instead. Additionally, if your VSCode setup also has any tasks that run Bazel commands on open, those might temporarily block the server from starting up because of the Bazel lock; the server will still spin up once it is able to acquire the lock.
 
 Alternatively, you can build `starpls` with Bazel:

--- a/crates/starpls/src/check.rs
+++ b/crates/starpls/src/check.rs
@@ -46,7 +46,7 @@ pub(crate) fn run_check(paths: Vec<String>, output_base: Option<String>) -> anyh
         fetch_repo_sender,
         bzlmod_enabled,
     );
-    let mut analysis = Analysis::new(Arc::new(loader));
+    let mut analysis = Analysis::new(Arc::new(loader), Default::default());
     let mut change = Change::default();
     let mut file_ids = Vec::new();
     let mut original_paths = FxHashMap::default();

--- a/crates/starpls/src/main.rs
+++ b/crates/starpls/src/main.rs
@@ -43,8 +43,12 @@ enum Commands {
 
 #[derive(Args, Default)]
 pub(crate) struct ServerArgs {
+    /// Path to the Bazel binary.
     #[clap(long = "bazel_path")]
     bazel_path: Option<String>,
+    /// Infer attributes on a rule implementation function's context parameter.
+    #[clap(long = "experimental_infer_ctx_attributes", default_value_t = false)]
+    experimental_infer_ctx_attributes: bool,
 }
 
 fn main() -> anyhow::Result<()> {

--- a/crates/starpls/src/server.rs
+++ b/crates/starpls/src/server.rs
@@ -9,7 +9,7 @@ use starpls_bazel::{
     decode_builtins, Builtins,
 };
 use starpls_common::FileId;
-use starpls_ide::{Analysis, AnalysisSnapshot, Change};
+use starpls_ide::{Analysis, AnalysisSnapshot, Change, InferenceOptions};
 
 use crate::{
     config::ServerConfig,
@@ -164,7 +164,12 @@ impl Server {
             bzlmod_enabled,
         );
 
-        let mut analysis = Analysis::new(Arc::new(loader));
+        let mut analysis = Analysis::new(
+            Arc::new(loader),
+            InferenceOptions {
+                infer_ctx_attrs: config.args.experimental_infer_ctx_attributes,
+            },
+        );
         analysis.set_builtin_defs(builtins, rules);
 
         let server = Server {

--- a/crates/starpls_bazel/src/lib.rs
+++ b/crates/starpls_bazel/src/lib.rs
@@ -48,6 +48,7 @@ pub const BUILTINS_TYPES_DENY_LIST: &[&str] = &[
     "range",
     "string",
     "struct",
+    "Target",
     "tuple",
     "None",
     "NoneType",

--- a/crates/starpls_hir/src/api.rs
+++ b/crates/starpls_hir/src/api.rs
@@ -77,8 +77,9 @@ impl<'a> Semantics<'a> {
     }
 
     pub fn type_of_param(&self, file: File, param: &ast::Parameter) -> Option<Type> {
-        let ptr = AstPtr::new(param);
-        let param = source_map(self.db, file).param_map.get(&ptr)?;
+        let param = source_map(self.db, file)
+            .param_map
+            .get(&AstPtr::new(param))?;
         Some(self.db.infer_param(file, *param).into())
     }
 
@@ -316,7 +317,7 @@ impl Type {
     pub fn doc(&self, db: &dyn Db) -> Option<String> {
         Some(match self.ty.kind() {
             TyKind::BuiltinFunction(func) => func.doc(db).clone(),
-            TyKind::BuiltinType(type_) => type_.doc(db).clone(),
+            TyKind::BuiltinType(ty, _) => ty.doc(db).clone(),
             TyKind::Function(func) => return func.doc(db).map(|doc| doc.to_string()),
             TyKind::IntrinsicFunction(func, _) => func.doc(db).clone(),
             TyKind::Rule(rule) => return rule.doc.as_ref().map(Box::to_string),

--- a/crates/starpls_hir/src/api.rs
+++ b/crates/starpls_hir/src/api.rs
@@ -23,6 +23,8 @@ use crate::{
     Db, ExprId, Name, TyKind,
 };
 
+const TARGET_DOC: &str = "The BUILD target for a dependency. Appears in the fields of `ctx.attr` corresponding to dependency attributes (`label` or `label_list`).";
+
 pub fn diagnostics_for_file(db: &dyn Db, file: File) -> impl Iterator<Item = Diagnostic> {
     module_scopes::accumulated::<Diagnostics>(db, file).into_iter()
 }
@@ -327,6 +329,7 @@ impl Type {
             | TyKind::ModuleExtensionProxy(module_extension) => {
                 return module_extension.doc.as_ref().map(Box::to_string)
             }
+            TyKind::Target => TARGET_DOC.into(),
             _ => return None,
         })
     }
@@ -349,7 +352,7 @@ impl Type {
                         name: name.clone(),
                         doc: attr.doc.as_ref().map(|doc| doc.to_string()),
                     }),
-                    attr.expected_ty().into(),
+                    attr.resolved_ty().into(),
                 )
             }));
         }

--- a/crates/starpls_hir/src/def.rs
+++ b/crates/starpls_hir/src/def.rs
@@ -19,12 +19,16 @@ pub(crate) mod scope;
 mod tests;
 
 pub type ModulePtr = AstPtr<ast::Module>;
+
 pub type ExprId = Id<Expr>;
 pub type ExprPtr = AstPtr<ast::Expression>;
+
 pub type StmtId = Id<Stmt>;
 pub type StmtPtr = AstPtr<ast::Statement>;
+
 pub type ParamId = Id<Param>;
 pub type ParamPtr = AstPtr<ast::Parameter>;
+
 pub type LoadItemId = Id<LoadItem>;
 pub type LoadItemPtr = AstPtr<ast::LoadItem>;
 
@@ -302,9 +306,9 @@ pub(crate) enum Argument {
 pub enum Param {
     Simple {
         name: Name,
+        default: Option<ExprId>,
         type_ref: Option<TypeRef>,
         doc: Option<Box<str>>,
-        default: Option<ExprId>,
     },
     ArgsList {
         name: Name,
@@ -460,7 +464,7 @@ pub(crate) struct LiteralString {
 }
 
 #[salsa::tracked]
-pub struct Function {
+pub(crate) struct Function {
     pub(crate) file: File,
     pub(crate) name: Name,
     pub(crate) ret_type_ref: Option<TypeRef>,

--- a/crates/starpls_hir/src/def.rs
+++ b/crates/starpls_hir/src/def.rs
@@ -19,16 +19,12 @@ pub(crate) mod scope;
 mod tests;
 
 pub type ModulePtr = AstPtr<ast::Module>;
-
 pub type ExprId = Id<Expr>;
 pub type ExprPtr = AstPtr<ast::Expression>;
-
 pub type StmtId = Id<Stmt>;
 pub type StmtPtr = AstPtr<ast::Statement>;
-
 pub type ParamId = Id<Param>;
 pub type ParamPtr = AstPtr<ast::Parameter>;
-
 pub type LoadItemId = Id<LoadItem>;
 pub type LoadItemPtr = AstPtr<ast::LoadItem>;
 
@@ -40,6 +36,8 @@ pub struct Module {
     pub(crate) load_items: Arena<LoadItem>,
     pub(crate) top_level: Box<[StmtId]>,
     pub(crate) type_ignore_comment_lines: HashSet<u32>,
+    pub(crate) call_expr_with_impl_fn: FxHashMap<Name, ExprId>,
+    pub(crate) param_to_def_stmt: FxHashMap<ParamId, StmtId>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -304,9 +302,9 @@ pub(crate) enum Argument {
 pub enum Param {
     Simple {
         name: Name,
-        default: Option<ExprId>,
         type_ref: Option<TypeRef>,
         doc: Option<Box<str>>,
+        default: Option<ExprId>,
     },
     ArgsList {
         name: Name,
@@ -462,7 +460,7 @@ pub(crate) struct LiteralString {
 }
 
 #[salsa::tracked]
-pub(crate) struct Function {
+pub struct Function {
     pub(crate) file: File,
     pub(crate) name: Name,
     pub(crate) ret_type_ref: Option<TypeRef>,

--- a/crates/starpls_hir/src/display.rs
+++ b/crates/starpls_hir/src/display.rs
@@ -289,6 +289,7 @@ impl DisplayWithDb for TyKind {
             TyKind::ModuleExtension(_) => "module_extension",
             TyKind::ModuleExtensionProxy(_) => "module_extension_proxy",
             TyKind::Tag(_) => "tag",
+            TyKind::Target => "Target",
         };
 
         f.write_str(text)

--- a/crates/starpls_hir/src/display.rs
+++ b/crates/starpls_hir/src/display.rs
@@ -256,7 +256,7 @@ impl DisplayWithDb for TyKind {
                 f.write_str(") -> ")?;
                 return func.ret_type_ref(db).fmt(f);
             }
-            TyKind::BuiltinType(type_) => return f.write_str(type_.name(db).as_str()),
+            TyKind::BuiltinType(ty, _) => return f.write_str(ty.name(db).as_str()),
             TyKind::BoundVar(index) => return write!(f, "'{}", index),
             TyKind::Protocol(proto) => {
                 let (name, ty) = match proto {

--- a/crates/starpls_hir/src/lib.rs
+++ b/crates/starpls_hir/src/lib.rs
@@ -7,7 +7,7 @@ pub use crate::{
     api::*,
     def::{ExprId, LoadItemId, LoadStmt, Module, Name, ParamId},
     display::{DisplayWithDb, DisplayWithDbWrapper},
-    typeck::{builtins::BuiltinDefs, Cancelled, GlobalCtxt, Ty, TyCtxt},
+    typeck::{builtins::BuiltinDefs, Cancelled, GlobalCtxt, InferenceOptions, Ty, TyCtxt},
 };
 use crate::{
     def::ModuleSourceMap,

--- a/crates/starpls_hir/src/lib.rs
+++ b/crates/starpls_hir/src/lib.rs
@@ -1,6 +1,8 @@
 use starpls_bazel::Builtins;
 use starpls_common::{parse, Dialect, File, Parse};
 
+// The symbols from `def` crate are only exported to facilitate implementing the `Db` interface.
+// Ideally, we should find a way to avoid needing this, as it breaks the API boundary of this crate.
 pub use crate::{
     api::*,
     def::{ExprId, LoadItemId, LoadStmt, Module, Name, ParamId},

--- a/crates/starpls_hir/src/test_database.rs
+++ b/crates/starpls_hir/src/test_database.rs
@@ -5,10 +5,7 @@ use starpls_bazel::{APIContext, Builtins};
 use starpls_common::{File, FileId, LoadItemCandidate, ResolvedPath};
 use starpls_test_util::{make_test_builtins, FixtureType};
 
-use crate::{
-    def::{ExprId, Function},
-    BuiltinDefs, Db, Dialect, GlobalCtxt, LoadItemId, ParamId, Ty,
-};
+use crate::{def::ExprId, BuiltinDefs, Db, Dialect, GlobalCtxt, LoadItemId, ParamId, Ty};
 
 #[derive(Default)]
 #[salsa::db(starpls_common::Jar, crate::Jar)]

--- a/crates/starpls_hir/src/test_database.rs
+++ b/crates/starpls_hir/src/test_database.rs
@@ -5,7 +5,10 @@ use starpls_bazel::{APIContext, Builtins};
 use starpls_common::{File, FileId, LoadItemCandidate, ResolvedPath};
 use starpls_test_util::{make_test_builtins, FixtureType};
 
-use crate::{def::ExprId, BuiltinDefs, Db, Dialect, GlobalCtxt, LoadItemId, ParamId, Ty};
+use crate::{
+    def::{ExprId, Function},
+    BuiltinDefs, Db, Dialect, GlobalCtxt, LoadItemId, ParamId, Ty,
+};
 
 #[derive(Default)]
 #[salsa::db(starpls_common::Jar, crate::Jar)]

--- a/crates/starpls_hir/src/typeck/builtins.rs
+++ b/crates/starpls_hir/src/typeck/builtins.rs
@@ -283,8 +283,7 @@ impl BuiltinFunction {
                                                 )),
                                                 _ => None,
                                             })
-                                            .collect::<Vec<_>>()
-                                            .into_boxed_slice(),
+                                            .collect::<Vec<_>>(),
                                     )
                                 }
                             }
@@ -300,7 +299,7 @@ impl BuiltinFunction {
                         RuleKind::Repository
                     },
                     doc: doc.map(|doc| doc.value(db).clone()),
-                    attrs: attrs.unwrap_or_else(|| Vec::new().into_boxed_slice()),
+                    attrs: Arc::new(attrs.unwrap_or_default()),
                 })
             }
 
@@ -619,13 +618,16 @@ pub(crate) fn builtin_types_query(db: &dyn Db, defs: BuiltinDefs) -> BuiltinType
 
         types.insert(
             type_.name.clone(),
-            TyKind::BuiltinType(BuiltinType::new(
-                db,
-                Name::from_str(&type_.name),
-                fields,
-                methods,
-                normalize_doc_text(&type_.doc),
-            ))
+            TyKind::BuiltinType(
+                BuiltinType::new(
+                    db,
+                    Name::from_str(&type_.name),
+                    fields,
+                    methods,
+                    normalize_doc_text(&type_.doc),
+                ),
+                None,
+            )
             .intern(),
         );
     }

--- a/crates/starpls_hir/src/typeck/infer.rs
+++ b/crates/starpls_hir/src/typeck/infer.rs
@@ -242,7 +242,7 @@ impl TyCtxt<'_> {
                                             .iter()
                                             .find_map(|(name, attr)| {
                                                 if name == field {
-                                                    Some(attr.expected_ty())
+                                                    Some(attr.resolved_ty())
                                                 } else {
                                                     None
                                                 }
@@ -310,15 +310,11 @@ impl TyCtxt<'_> {
                     TyKind::Range => (&int_ty, &int_ty, "range"),
                     kind => {
                         let return_ty = match (kind, index_ty.kind()) {
-                            (TyKind::Any | TyKind::Unknown, TyKind::Provider(provider)) => {
-                                Some(TyKind::ProviderInstance(provider.clone()).intern())
-                            }
+                            (
+                                TyKind::Any | TyKind::Unknown | TyKind::Target,
+                                TyKind::Provider(provider),
+                            ) => Some(TyKind::ProviderInstance(provider.clone()).intern()),
                             (TyKind::Any | TyKind::Unknown, _) => Some(Ty::unknown()),
-                            (TyKind::BuiltinType(builtin, None), TyKind::Provider(provider))
-                                if builtin.name(db).as_str() == "Target" =>
-                            {
-                                Some(TyKind::ProviderInstance(provider.clone()).intern())
-                            }
                             _ => None,
                         }
                         .unwrap_or_else(|| {

--- a/crates/starpls_hir/src/typeck/infer.rs
+++ b/crates/starpls_hir/src/typeck/infer.rs
@@ -6,7 +6,6 @@ use starpls_syntax::{
     TextRange,
 };
 
-use super::{builtins::builtin_types, RuleKind, TyData};
 use crate::{
     def::{
         resolver::{Export, Resolver},
@@ -18,11 +17,12 @@ use crate::{
     module, source_map,
     typeck::{
         assign_tys,
+        builtins::builtin_types,
         call::{Slot, SlotProvider, Slots},
         intrinsics::{IntrinsicFunctionParam, IntrinsicTypes},
         resolve_type_ref, resolve_type_ref_opt, DictLiteral, FileExprId, FileLoadItemId,
-        FileLoadStmt, FileParamId, Protocol, Struct, Substitution, Tuple, Ty, TyCtxt, TyKind,
-        TypeRef, TypecheckCancelled,
+        FileLoadStmt, FileParamId, Protocol, RuleKind, Struct, Substitution, Tuple, Ty, TyCtxt,
+        TyData, TyKind, TypeRef, TypecheckCancelled,
     },
     Name,
 };

--- a/crates/starpls_hir/src/typeck/infer.rs
+++ b/crates/starpls_hir/src/typeck/infer.rs
@@ -1195,7 +1195,11 @@ impl TyCtxt<'_> {
         }
 
         let ty = self
-            .infer_param_from_rule_usage(file, param)
+            .shared_state
+            .options
+            .infer_ctx_attrs
+            .then(|| self.infer_param_from_rule_usage(file, param))
+            .and_then(|ty| ty)
             .unwrap_or_else(|| match &module(self.db, file)[param] {
                 Param::Simple { type_ref, .. } => type_ref
                     .as_ref()

--- a/crates/starpls_hir/src/typeck/tests.rs
+++ b/crates/starpls_hir/src/typeck/tests.rs
@@ -67,23 +67,23 @@ fn check_infer(input: &str, expect: Expect) {
         .unwrap();
     }
 
-    for (ptr, _) in source_map
-        .param_map
-        .keys()
-        .map(|ptr| (ptr, ptr.syntax_node_ptr().text_range()))
-        .sorted_by(|(_, lhs), (_, rhs)| {
-            if lhs.contains_range(rhs.clone()) {
-                Ordering::Greater
-            } else if rhs.contains_range(lhs.clone()) {
-                Ordering::Less
-            } else {
-                lhs.start().cmp(&rhs.start())
-            }
-        })
-    {
-        let param = *source_map.param_map.get(&ptr).unwrap();
-        db.infer_param(file, param);
-    }
+    // for (ptr, _) in source_map
+    //     .param_map
+    //     .keys()
+    //     .map(|ptr| (ptr, ptr.syntax_node_ptr().text_range()))
+    //     .sorted_by(|(_, lhs), (_, rhs)| {
+    //         if lhs.contains_range(rhs.clone()) {
+    //             Ordering::Greater
+    //         } else if rhs.contains_range(lhs.clone()) {
+    //             Ordering::Less
+    //         } else {
+    //             lhs.start().cmp(&rhs.start())
+    //         }
+    //     })
+    // {
+    //     let param = *source_map.param_map.get(&ptr).unwrap();
+    //     db.infer_param(file, param);
+    // }
 
     let diagnostics = db.gcx.with_tcx(&db, |tcx| tcx.diagnostics_for_file(file));
     if !diagnostics.is_empty() {

--- a/crates/starpls_hir/src/typeck/tests.rs
+++ b/crates/starpls_hir/src/typeck/tests.rs
@@ -67,23 +67,23 @@ fn check_infer(input: &str, expect: Expect) {
         .unwrap();
     }
 
-    // for (ptr, _) in source_map
-    //     .param_map
-    //     .keys()
-    //     .map(|ptr| (ptr, ptr.syntax_node_ptr().text_range()))
-    //     .sorted_by(|(_, lhs), (_, rhs)| {
-    //         if lhs.contains_range(rhs.clone()) {
-    //             Ordering::Greater
-    //         } else if rhs.contains_range(lhs.clone()) {
-    //             Ordering::Less
-    //         } else {
-    //             lhs.start().cmp(&rhs.start())
-    //         }
-    //     })
-    // {
-    //     let param = *source_map.param_map.get(&ptr).unwrap();
-    //     db.infer_param(file, param);
-    // }
+    for (ptr, _) in source_map
+        .param_map
+        .keys()
+        .map(|ptr| (ptr, ptr.syntax_node_ptr().text_range()))
+        .sorted_by(|(_, lhs), (_, rhs)| {
+            if lhs.contains_range(rhs.clone()) {
+                Ordering::Greater
+            } else if rhs.contains_range(lhs.clone()) {
+                Ordering::Less
+            } else {
+                lhs.start().cmp(&rhs.start())
+            }
+        })
+    {
+        let param = *source_map.param_map.get(&ptr).unwrap();
+        db.infer_param(file, param);
+    }
 
     let diagnostics = db.gcx.with_tcx(&db, |tcx| tcx.diagnostics_for_file(file));
     if !diagnostics.is_empty() {

--- a/crates/starpls_hir/src/typeck/tests.rs
+++ b/crates/starpls_hir/src/typeck/tests.rs
@@ -1108,10 +1108,10 @@ my_rule = repository_rule(
             32..35 "ctx": ctx
             32..40 "ctx.file": struct
             32..44 "ctx.file.foo": File
-            49..53 "srcs": list[string]
+            49..53 "srcs": list[Target]
             56..59 "ctx": ctx
             56..64 "ctx.attr": struct
-            56..69 "ctx.attr.srcs": list[string]
+            56..69 "ctx.attr.srcs": list[Target]
             71..78 "my_rule": rule
             81..85 "rule": def rule(*args, **kwargs) -> Unknown
             108..118 "_rule_impl": def _rule_impl(ctx) -> Unknown
@@ -1121,10 +1121,10 @@ my_rule = repository_rule(
             150..167 "attr.label_list()": Attribute
             132..174 "{\n        \"srcs\": attr.label_list(),\n    }": dict[string, Attribute]
             81..177 "rule(\n    implementation = _rule_impl,\n    attrs = {\n        \"srcs\": attr.label_list(),\n    },\n)": rule
-            226..230 "srcs": list[string]
+            226..230 "srcs": list[Target]
             233..247 "repository_ctx": repository_ctx
             233..252 "repository_ctx.attr": struct
-            233..257 "repository_ctx.attr.srcs": list[string]
+            233..257 "repository_ctx.attr.srcs": list[Target]
             259..266 "my_rule": repository_rule
             269..284 "repository_rule": def repository_rule(implementation: Unknown, attrs: dict[string, Unknown] | None = None, local: bool = None, environ: Sequence[string] = [], configure: bool = False, remotable: bool = False, doc: string | None = None) -> callable
             307..328 "_repository_rule_impl": def _repository_rule_impl(repository_ctx) -> Unknown

--- a/crates/starpls_hir/src/typeck/tests.rs
+++ b/crates/starpls_hir/src/typeck/tests.rs
@@ -7,25 +7,39 @@ use starpls_common::{parse, Db as _, Dialect, FileId};
 use starpls_syntax::ast::AstNode;
 use starpls_test_util::FixtureType;
 
-use crate::{source_map, test_database::TestDatabaseBuilder, Db as _, DisplayWithDb};
+use crate::{
+    source_map, test_database::TestDatabaseBuilder, Db as _, DisplayWithDb, InferenceOptions,
+};
 
 fn check_infer(input: &str, expect: Expect) {
+    check_infer_with_options(input, expect, Default::default())
+}
+
+fn check_infer_with_options(input: &str, expect: Expect, options: InferenceOptions) {
     let mut builder = TestDatabaseBuilder::default();
     builder.add_function("provider");
+    builder.add_function("rule");
     builder.add_function("struct");
-    builder.add_type(FixtureType {
-        name: "File".to_string(),
-        fields: vec![],
-    });
-    builder.add_type(FixtureType {
-        name: "ctx".to_string(),
-        fields: vec![
-            ("executable".to_string(), "struct".to_string()),
-            ("file".to_string(), "struct".to_string()),
-            ("files".to_string(), "struct".to_string()),
-            ("outputs".to_string(), "struct".to_string()),
+    builder.add_type(FixtureType::new("File", vec![], vec![]));
+    builder.add_type(FixtureType::new(
+        "ctx",
+        vec![
+            ("attr", "struct"),
+            ("executable", "struct"),
+            ("file", "struct"),
+            ("files", "struct"),
+            ("outputs", "struct"),
         ],
-    });
+        vec![],
+    ));
+    builder.add_type(FixtureType::new(
+        "repository_ctx",
+        vec![("attr", "struct")],
+        vec![],
+    ));
+    builder.add_type(FixtureType::new("attr", vec![], vec!["label_list"]));
+    builder.add_global("attr", "attr");
+    builder.set_inference_options(options);
 
     let mut db = builder.build();
     let file_id = FileId(0);
@@ -1060,6 +1074,106 @@ def _impl(ctx):
             108..111 "ctx": ctx
             108..119 "ctx.outputs": struct
             108..123 "ctx.outputs.qux": File
+        "#]],
+    );
+}
+
+#[test]
+fn test_infer_ctx_attrs() {
+    check_infer_with_options(
+        r#"
+def _rule_impl(ctx):
+    foo = ctx.file.foo
+    srcs = ctx.attr.srcs
+
+my_rule = rule(
+    implementation = _rule_impl,
+    attrs = {
+        "srcs": attr.label_list(),
+    },
+)
+
+def _repository_rule_impl(repository_ctx):
+    srcs = repository_ctx.attr.srcs
+
+my_rule = repository_rule(
+    implementation = _repository_rule_impl,
+    attrs = {
+        "srcs": attr.label_list(),
+    },
+)
+"#,
+        expect![[r#"
+            26..29 "foo": File
+            32..35 "ctx": ctx
+            32..40 "ctx.file": struct
+            32..44 "ctx.file.foo": File
+            49..53 "srcs": list[string]
+            56..59 "ctx": ctx
+            56..64 "ctx.attr": struct
+            56..69 "ctx.attr.srcs": list[string]
+            71..78 "my_rule": rule
+            81..85 "rule": def rule(*args, **kwargs) -> Unknown
+            108..118 "_rule_impl": def _rule_impl(ctx) -> Unknown
+            142..148 "\"srcs\"": Literal["srcs"]
+            150..154 "attr": attr
+            150..165 "attr.label_list": def label_list(*args, **kwargs) -> Unknown
+            150..167 "attr.label_list()": Attribute
+            132..174 "{\n        \"srcs\": attr.label_list(),\n    }": dict[string, Attribute]
+            81..177 "rule(\n    implementation = _rule_impl,\n    attrs = {\n        \"srcs\": attr.label_list(),\n    },\n)": rule
+            226..230 "srcs": list[string]
+            233..247 "repository_ctx": repository_ctx
+            233..252 "repository_ctx.attr": struct
+            233..257 "repository_ctx.attr.srcs": list[string]
+            259..266 "my_rule": repository_rule
+            269..284 "repository_rule": def repository_rule(implementation: Unknown, attrs: dict[string, Unknown] | None = None, local: bool = None, environ: Sequence[string] = [], configure: bool = False, remotable: bool = False, doc: string | None = None) -> callable
+            307..328 "_repository_rule_impl": def _repository_rule_impl(repository_ctx) -> Unknown
+            352..358 "\"srcs\"": Literal["srcs"]
+            360..364 "attr": attr
+            360..375 "attr.label_list": def label_list(*args, **kwargs) -> Unknown
+            360..377 "attr.label_list()": Attribute
+            342..384 "{\n        \"srcs\": attr.label_list(),\n    }": dict[string, Attribute]
+            269..387 "repository_rule(\n    implementation = _repository_rule_impl,\n    attrs = {\n        \"srcs\": attr.label_list(),\n    },\n)": repository_rule
+        "#]],
+        InferenceOptions {
+            infer_ctx_attrs: true,
+        },
+    );
+}
+
+#[test]
+fn test_infer_ctx_attrs_disabled() {
+    check_infer(
+        r#"
+def _rule_impl(ctx):
+    foo = ctx.file.foo
+    srcs = ctx.attr.srcs
+
+my_rule = rule(
+    implementation = _rule_impl,
+    attrs = {
+        "srcs": attr.label_list(),
+    },
+)    
+"#,
+        expect![[r#"
+            26..29 "foo": Unknown
+            32..35 "ctx": Unknown
+            32..40 "ctx.file": Unknown
+            32..44 "ctx.file.foo": Unknown
+            49..53 "srcs": Unknown
+            56..59 "ctx": Unknown
+            56..64 "ctx.attr": Unknown
+            56..69 "ctx.attr.srcs": Unknown
+            71..78 "my_rule": rule
+            81..85 "rule": def rule(*args, **kwargs) -> Unknown
+            108..118 "_rule_impl": def _rule_impl(ctx) -> Unknown
+            142..148 "\"srcs\"": Literal["srcs"]
+            150..154 "attr": attr
+            150..165 "attr.label_list": def label_list(*args, **kwargs) -> Unknown
+            150..167 "attr.label_list()": Attribute
+            132..174 "{\n        \"srcs\": attr.label_list(),\n    }": dict[string, Attribute]
+            81..177 "rule(\n    implementation = _rule_impl,\n    attrs = {\n        \"srcs\": attr.label_list(),\n    },\n)": rule
         "#]],
     );
 }


### PR DESCRIPTION
Fixes: https://github.com/withered-magic/starpls/issues/224
Fixes: https://github.com/withered-magic/starpls/issues/152

This PR adds a heuristic for inferring fields on `ctx.attr` based on usage of the corresponding implementation function within the current file. For example, given

```python
def _impl(ctx):
    print(ctx.attr.bar)

my_rule = rule(
    implementation=_impl,
    name = "foo",
    attrs = {
        "bar": attr.string(),
    },
)
```

then `ctx.attr.bar` will be inferred as a `string` because it is used the `my_rule` declaration. Note that the `# type: (ctx) -> Unknown` comment is no longer required. Additionally, completions on `ctx.attr` will be offered.

TODO:
- [x] Gate functionality behind `--experimental_infer_ctx_attributes` flag
- [x] Add tests

