### PR TITLE
feat: support Bazel prelude

### DIFF
--- a/crates/starpls/src/check.rs
+++ b/crates/starpls/src/check.rs
@@ -3,7 +3,7 @@ use std::{fmt::Write, fs, path::PathBuf, process, sync::Arc};
 use anyhow::anyhow;
 use rustc_hash::FxHashMap;
 use starpls_bazel::client::{BazelCLI, BazelClient};
-use starpls_common::Severity;
+use starpls_common::{FileInfo, Severity};
 use starpls_ide::{Analysis, Change};
 
 use crate::{
@@ -42,7 +42,7 @@ pub(crate) fn run_check(paths: Vec<String>, output_base: Option<String>) -> anyh
         bazel_client,
         interner.clone(),
         info.workspace,
-        external_output_base,
+        external_output_base.clone(),
         fetch_repo_sender,
         bzlmod_enabled,
     );
@@ -64,10 +64,13 @@ pub(crate) fn run_check(paths: Vec<String>, output_base: Option<String>) -> anyh
             Some(res) => res,
             None => return Err(err()),
         };
-
+        let info = api_context.map(|api_context| FileInfo::Bazel {
+            api_context,
+            is_external: resolved.starts_with(&external_output_base),
+        });
         let file_id = interner.intern_path(resolved);
         original_paths.insert(file_id, path);
-        change.create_file(file_id, dialect, api_context, contents);
+        change.create_file(file_id, dialect, info, contents);
         file_ids.push(file_id);
     }
 

--- a/crates/starpls/src/check.rs
+++ b/crates/starpls/src/check.rs
@@ -41,7 +41,7 @@ pub(crate) fn run_check(paths: Vec<String>, output_base: Option<String>) -> anyh
     let loader = DefaultFileLoader::new(
         bazel_client,
         interner.clone(),
-        info.workspace,
+        info.workspace.clone(),
         external_output_base.clone(),
         fetch_repo_sender,
         bzlmod_enabled,
@@ -60,7 +60,10 @@ pub(crate) fn run_check(paths: Vec<String>, output_base: Option<String>) -> anyh
         }
 
         let contents = fs::read_to_string(&resolved).map_err(|_| err())?;
-        let (dialect, api_context) = match document::dialect_and_api_context_for_path(&resolved) {
+        let (dialect, api_context) = match document::dialect_and_api_context_for_workspace_path(
+            &info.workspace,
+            &resolved,
+        ) {
             Some(res) => res,
             None => return Err(err()),
         };

--- a/crates/starpls/src/document.rs
+++ b/crates/starpls/src/document.rs
@@ -472,7 +472,7 @@ impl FileLoader for DefaultFileLoader {
                     }
                 };
 
-                let is_external = resolved_path.starts_with(&self.external_output_base);
+                let is_external = !resolved_path.starts_with(&self.workspace);
                 (
                     resolved_path,
                     Some(FileInfo::Bazel {

--- a/crates/starpls/src/document.rs
+++ b/crates/starpls/src/document.rs
@@ -19,7 +19,9 @@ use starpls_bazel::{
     label::{PartialParse, RepoKind},
     APIContext, Label, ParseError,
 };
-use starpls_common::{Dialect, FileId, LoadItemCandidate, LoadItemCandidateKind, ResolvedPath};
+use starpls_common::{
+    Dialect, FileId, FileInfo, LoadItemCandidate, LoadItemCandidateKind, ResolvedPath,
+};
 use starpls_ide::FileLoader;
 
 use crate::event_loop::{FetchExternalRepoRequest, Task};
@@ -41,7 +43,7 @@ impl From<Option<i32>> for DocumentSource {
 pub(crate) struct Document {
     pub(crate) contents: String,
     pub(crate) dialect: Dialect,
-    pub(crate) api_context: Option<APIContext>,
+    pub(crate) info: Option<FileInfo>,
     pub(crate) source: DocumentSource,
 }
 
@@ -49,13 +51,13 @@ impl Document {
     fn new(
         contents: String,
         dialect: Dialect,
-        api_context: Option<APIContext>,
+        info: Option<FileInfo>,
         version: Option<i32>,
     ) -> Self {
         Self {
             contents,
             dialect,
-            api_context,
+            info,
             source: version.into(),
         }
     }
@@ -72,29 +74,37 @@ pub(crate) struct DocumentManager {
     has_closed_or_opened_documents: bool,
     changed_file_ids: Vec<(FileId, DocumentChangeKind)>,
     path_interner: Arc<PathInterner>,
+    external_output_base: PathBuf,
 }
 
 impl DocumentManager {
-    pub(crate) fn new(path_interner: Arc<PathInterner>) -> Self {
+    pub(crate) fn new(path_interner: Arc<PathInterner>, external_output_base: PathBuf) -> Self {
         Self {
             documents: Default::default(),
             has_closed_or_opened_documents: false,
             changed_file_ids: Default::default(),
             path_interner,
+            external_output_base,
         }
     }
 
     pub(crate) fn open(&mut self, path: PathBuf, version: i32, contents: String) {
         // Create/update the document with the given contents.
         self.has_closed_or_opened_documents = true;
-        let (dialect, api_context) = match dialect_and_api_context_for_path(&path) {
-            Some(res) => res,
+        let (dialect, info) = match dialect_and_api_context_for_path(&path) {
+            Some((dialect, api_context)) => (
+                dialect,
+                api_context.map(|api_context| FileInfo::Bazel {
+                    api_context,
+                    is_external: path.starts_with(&self.external_output_base),
+                }),
+            ),
             None => return,
         };
         let file_id = self.path_interner.intern_path(path);
         self.documents.insert(
             file_id,
-            Document::new(contents, dialect, api_context, Some(version)),
+            Document::new(contents, dialect, info, Some(version)),
         );
         self.changed_file_ids
             .push((file_id, DocumentChangeKind::Create));
@@ -424,8 +434,8 @@ impl FileLoader for DefaultFileLoader {
         path: &str,
         dialect: Dialect,
         from: FileId,
-    ) -> anyhow::Result<Option<(FileId, Dialect, Option<APIContext>, Option<String>)>> {
-        let (path, api_context, canonical_repo) = match dialect {
+    ) -> anyhow::Result<Option<(FileId, Dialect, Option<FileInfo>, Option<String>)>> {
+        let (path, info, canonical_repo) = match dialect {
             Dialect::Standard => {
                 // Find the importing file's directory.
                 let mut from_path = self.interner.lookup_by_file_id(from);
@@ -461,12 +471,20 @@ impl FileLoader for DefaultFileLoader {
                     }
                 };
 
-                (resolved_path, Some(APIContext::Bzl), canonical_repo)
+                let is_external = resolved_path.starts_with(&self.external_output_base);
+                (
+                    resolved_path,
+                    Some(FileInfo::Bazel {
+                        api_context: APIContext::Bzl,
+                        is_external,
+                    }),
+                    canonical_repo,
+                )
             }
         };
 
         let (file_id, contents) = self.maybe_intern_file(path, from, canonical_repo)?;
-        Ok(Some((file_id, dialect, api_context, contents)))
+        Ok(Some((file_id, dialect, info, contents)))
     }
 
     fn list_load_candidates(

--- a/crates/starpls/src/document.rs
+++ b/crates/starpls/src/document.rs
@@ -145,7 +145,7 @@ pub(crate) struct PathInterner {
 
 impl PathInterner {
     pub(crate) fn intern_path(&self, path: PathBuf) -> FileId {
-        let index = self.map.write().insert_full(path.clone()).0;
+        let index = self.map.write().insert_full(path).0;
         FileId(index as u32)
     }
 
@@ -633,9 +633,14 @@ pub(crate) fn dialect_and_api_context_for_path(
             (Dialect::Bazel, Some(APIContext::Workspace))
         }
         _ => match path.extension().and_then(|ext| ext.to_str()) {
-            Some("sky" | "star") => (Dialect::Standard, None),
             Some("bzl") => (Dialect::Bazel, Some(APIContext::Bzl)),
-            _ => return None,
+            _ => {
+                if path.ends_with("tools/build_rules/prelude_bazel") {
+                    (Dialect::Bazel, Some(APIContext::Prelude))
+                } else {
+                    (Dialect::Standard, None)
+                }
+            }
         },
     })
 }

--- a/crates/starpls/src/main.rs
+++ b/crates/starpls/src/main.rs
@@ -62,7 +62,7 @@ fn main() -> anyhow::Result<()> {
 }
 
 fn run_server(args: ServerArgs) -> anyhow::Result<()> {
-    eprintln!("server: starpls, v0.1.12");
+    eprintln!("server: starpls, v0.1.13");
 
     // Create the transport over stdio.
     let (connection, io_threads) = Connection::stdio();

--- a/crates/starpls_bazel/src/lib.rs
+++ b/crates/starpls_bazel/src/lib.rs
@@ -86,7 +86,7 @@ pub const BUILTINS_VALUES_DENY_LIST: &[&str] = &[
     "zip",
 ];
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum APIContext {
     Bzl,
     Build,

--- a/crates/starpls_bazel/src/lib.rs
+++ b/crates/starpls_bazel/src/lib.rs
@@ -93,6 +93,7 @@ pub enum APIContext {
     Module,
     Repo,
     Workspace,
+    Prelude,
 }
 
 pub fn load_builtins(path: impl AsRef<Path>) -> anyhow::Result<Builtins> {

--- a/crates/starpls_hir/src/api.rs
+++ b/crates/starpls_hir/src/api.rs
@@ -271,6 +271,13 @@ impl SemanticsScope<'_> {
             .map(|(name, def)| (name, def.into()))
     }
 
+    pub fn exports(&self) -> impl Iterator<Item = (Name, ScopeDef)> {
+        self.resolver
+            .module_defs(true)
+            .into_iter()
+            .map(|(name, def)| (name, def.into()))
+    }
+
     pub fn resolve_name(&self, name: &Name) -> Option<Vec<ScopeDef>> {
         self.resolver
             .resolve_name(&name)

--- a/crates/starpls_hir/src/def/resolver.rs
+++ b/crates/starpls_hir/src/def/resolver.rs
@@ -160,11 +160,10 @@ impl<'a> Resolver<'a> {
                 let prelude_resolver = Resolver::new_for_module(self.db, prelude_file);
                 names.extend(
                     prelude_resolver
-                        .module_names()
+                        .module_defs(true)
                         .into_iter()
-                        .filter(|(name, def)| {
-                            !name.as_str().starts_with('_')
-                                && matches!(def, ScopeDef::Variable(_) | ScopeDef::Function(_))
+                        .filter(|(_, def)| {
+                            matches!(def, ScopeDef::Variable(_) | ScopeDef::Function(_))
                         }),
                 );
             }

--- a/crates/starpls_hir/src/def/resolver.rs
+++ b/crates/starpls_hir/src/def/resolver.rs
@@ -151,7 +151,7 @@ impl<'a> Resolver<'a> {
         };
 
         // If this is a BUILD file, add names from the prelude.
-        if api_context == APIContext::Build {
+        if api_context == APIContext::Build && self.file.is_external(self.db) == Some(false) {
             if let Some(prelude_file) = self
                 .db
                 .get_bazel_prelude_file()

--- a/crates/starpls_hir/src/def/resolver.rs
+++ b/crates/starpls_hir/src/def/resolver.rs
@@ -53,6 +53,10 @@ impl<'a> Resolver<'a> {
     }
 
     pub(crate) fn resolve_export(&self, name: &Name) -> Option<Export> {
+        if name.as_str().starts_with('_') {
+            return None;
+        }
+
         self.scopes().find_map(|scope| {
             scope
                 .declarations
@@ -158,8 +162,9 @@ impl<'a> Resolver<'a> {
                     prelude_resolver
                         .module_names()
                         .into_iter()
-                        .filter(|(_, def)| {
-                            matches!(def, ScopeDef::Variable(_) | ScopeDef::Function(_))
+                        .filter(|(name, def)| {
+                            !name.as_str().starts_with('_')
+                                && matches!(def, ScopeDef::Variable(_) | ScopeDef::Function(_))
                         }),
                 );
             }

--- a/crates/starpls_hir/src/def/scope.rs
+++ b/crates/starpls_hir/src/def/scope.rs
@@ -63,7 +63,7 @@ pub(crate) struct LoadItemDef {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct Scope {
-    pub(crate) declarations: FxHashMap<Name, Vec<ScopeDef>>,
+    pub(crate) defs: FxHashMap<Name, Vec<ScopeDef>>,
     pub(crate) parent: Option<ScopeId>,
 }
 
@@ -121,13 +121,13 @@ impl Scopes {
 
     fn alloc_scope(&mut self, parent: ScopeId) -> ScopeId {
         self.scopes.alloc(Scope {
-            declarations: Default::default(),
+            defs: Default::default(),
             parent: Some(parent),
         })
     }
 
     fn add_decl(&mut self, scope: ScopeId, name: Name, def: ScopeDef) {
-        match self.scopes[scope].declarations.entry(name) {
+        match self.scopes[scope].defs.entry(name) {
             Entry::Occupied(mut entry) => {
                 entry.get_mut().push(def);
             }
@@ -159,7 +159,7 @@ impl ScopeCollector<'_> {
     fn collect(mut self) -> Scopes {
         // Allocate the root module scope.
         let root = self.scopes.scopes.alloc(Scope {
-            declarations: Default::default(),
+            defs: Default::default(),
             parent: None,
         });
 

--- a/crates/starpls_hir/src/def/tests.rs
+++ b/crates/starpls_hir/src/def/tests.rs
@@ -1,5 +1,5 @@
 use starpls_bazel::APIContext;
-use starpls_common::{Dialect, File, FileId};
+use starpls_common::{Dialect, File, FileId, FileInfo};
 use starpls_test_util::parse_fixture;
 
 use crate::{def::resolver::Resolver, test_database::TestDatabase};
@@ -13,7 +13,10 @@ fn check_scope(fixture: &str, expected: &[&str]) {
         &test_db,
         file_id,
         Dialect::Bazel,
-        Some(APIContext::Bzl),
+        Some(FileInfo::Bazel {
+            api_context: APIContext::Bzl,
+            is_external: false,
+        }),
         text,
     );
     let resolver = Resolver::new_for_offset(&test_db, file, offset);

--- a/crates/starpls_hir/src/lib.rs
+++ b/crates/starpls_hir/src/lib.rs
@@ -1,5 +1,5 @@
 use starpls_bazel::Builtins;
-use starpls_common::{parse, Dialect, File, Parse};
+use starpls_common::{parse, Dialect, File, FileId, Parse};
 
 // The symbols from `def` crate are only exported to facilitate implementing the `Db` interface.
 // Ideally, we should find a way to avoid needing this, as it breaks the API boundary of this crate.
@@ -78,6 +78,10 @@ pub trait Db: salsa::DbWithJar<Jar> + starpls_common::Db {
     fn set_builtin_defs(&mut self, dialect: Dialect, builtins: Builtins, rules: Builtins);
 
     fn get_builtin_defs(&self, dialect: &Dialect) -> BuiltinDefs;
+
+    fn set_bazel_prelude_file(&mut self, file_id: FileId);
+
+    fn get_bazel_prelude_file(&self) -> Option<FileId>;
 }
 
 #[salsa::tracked]

--- a/crates/starpls_hir/src/test_database.rs
+++ b/crates/starpls_hir/src/test_database.rs
@@ -15,6 +15,7 @@ pub(crate) struct TestDatabase {
     builtin_defs: Arc<DashMap<Dialect, BuiltinDefs>>,
     storage: salsa::Storage<Self>,
     files: Arc<DashMap<FileId, File>>,
+    prelude_file: Option<FileId>,
     pub(crate) gcx: Arc<GlobalCtxt>,
 }
 
@@ -137,10 +138,12 @@ impl crate::Db for TestDatabase {
             ))
     }
 
-    fn set_bazel_prelude_file(&mut self, _file: FileId) {}
+    fn set_bazel_prelude_file(&mut self, file_id: FileId) {
+        self.prelude_file = Some(file_id)
+    }
 
     fn get_bazel_prelude_file(&self) -> Option<FileId> {
-        None
+        self.prelude_file
     }
 }
 

--- a/crates/starpls_hir/src/test_database.rs
+++ b/crates/starpls_hir/src/test_database.rs
@@ -136,6 +136,12 @@ impl crate::Db for TestDatabase {
                 Builtins::default(),
             ))
     }
+
+    fn set_bazel_prelude_file(&mut self, _file: FileId) {}
+
+    fn get_bazel_prelude_file(&self) -> Option<FileId> {
+        None
+    }
 }
 
 #[allow(unused)]

--- a/crates/starpls_hir/src/test_database.rs
+++ b/crates/starpls_hir/src/test_database.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use dashmap::{mapref::entry::Entry, DashMap};
-use starpls_bazel::{APIContext, Builtins};
-use starpls_common::{File, FileId, LoadItemCandidate, ResolvedPath};
+use starpls_bazel::Builtins;
+use starpls_common::{File, FileId, FileInfo, LoadItemCandidate, ResolvedPath};
 use starpls_test_util::{make_test_builtins, FixtureType};
 
 use crate::{
@@ -37,10 +37,10 @@ impl starpls_common::Db for TestDatabase {
         &mut self,
         file_id: FileId,
         dialect: Dialect,
-        api_context: Option<APIContext>,
+        info: Option<FileInfo>,
         contents: String,
     ) -> File {
-        let file = File::new(self, file_id, dialect, api_context, contents);
+        let file = File::new(self, file_id, dialect, info, contents);
         self.files.insert(file_id, file);
         file
     }

--- a/crates/starpls_hir/src/typeck/builtins.rs
+++ b/crates/starpls_hir/src/typeck/builtins.rs
@@ -443,7 +443,7 @@ impl BuiltinFunction {
                     loaded_file,
                     &Name::from_str(&name),
                 )? {
-                    Export::Variable(expr) => expr,
+                    Export::Variable(expr) => expr.expr,
                     _ => return None,
                 };
 

--- a/crates/starpls_hir/src/typeck/infer.rs
+++ b/crates/starpls_hir/src/typeck/infer.rs
@@ -99,7 +99,7 @@ impl TyCtxt<'_> {
                     .resolve_name(name)
                     .and_then(|decls| decls.into_iter().last())
                     .map(|decl| match decl {
-                        ScopeDef::Variable(VariableDef { expr, source, .. }) => self
+                        ScopeDef::Variable(VariableDef { file, expr, source }) => self
                             .cx
                             .type_of_expr
                             .get(&FileExprId::new(file, expr))
@@ -1358,7 +1358,9 @@ impl TyCtxt<'_> {
                                 loaded_file,
                                 &Name::from_str(name),
                             ) {
-                                Some(Export::Variable(expr)) => tcx.infer_expr(loaded_file, expr),
+                                Some(Export::Variable(expr)) => {
+                                    tcx.infer_expr(loaded_file, expr.expr)
+                                }
                                 Some(Export::Function(func)) => func.ty(),
                                 None => {
                                     tcx.add_diagnostic_for_range(

--- a/crates/starpls_hir/src/typeck/tests.rs
+++ b/crates/starpls_hir/src/typeck/tests.rs
@@ -3,7 +3,7 @@ use std::{cmp::Ordering, fmt::Write};
 use expect_test::{expect, Expect};
 use itertools::Itertools;
 use starpls_bazel::APIContext;
-use starpls_common::{parse, Db as _, Dialect, FileId};
+use starpls_common::{parse, Db as _, Dialect, FileId, FileInfo};
 use starpls_syntax::ast::AstNode;
 use starpls_test_util::FixtureType;
 
@@ -46,7 +46,10 @@ fn check_infer_with_options(input: &str, expect: Expect, options: InferenceOptio
     let file = db.create_file(
         file_id,
         Dialect::Bazel,
-        Some(APIContext::Bzl),
+        Some(FileInfo::Bazel {
+            api_context: APIContext::Bzl,
+            is_external: false,
+        }),
         input.to_string(),
     );
     let root = parse(&db, file).syntax(&db);

--- a/crates/starpls_ide/src/completions.rs
+++ b/crates/starpls_ide/src/completions.rs
@@ -221,18 +221,15 @@ pub(crate) fn completions(
             let file = db.get_file(file_id)?;
             let loaded_file = sema.resolve_load_stmt(file, &load_stmt)?;
             let scope = sema.scope_for_module(loaded_file);
-            for (name, decl) in scope
-                .names()
-                .filter(|(name, _)| !name.as_str().starts_with('_'))
-            {
+            for (name, def) in scope.exports() {
                 items.push(CompletionItem {
                     label: name.to_string(),
-                    kind: match &decl {
+                    kind: match &def {
                         ScopeDef::Callable(it) if it.is_user_defined() => {
                             CompletionItemKind::Function
                         }
                         ScopeDef::Variable(it) if it.is_user_defined() => {
-                            if decl.ty(db).is_callable() {
+                            if def.ty(db).is_callable() {
                                 CompletionItemKind::Function
                             } else {
                                 CompletionItemKind::Variable

--- a/crates/starpls_ide/src/document_symbols.rs
+++ b/crates/starpls_ide/src/document_symbols.rs
@@ -127,13 +127,19 @@ fn add_target_symbols(db: &Database, file: File, acc: &mut Vec<DocumentSymbol>) 
 mod tests {
     use expect_test::{expect, Expect};
     use starpls_bazel::APIContext;
-    use starpls_common::Dialect;
+    use starpls_common::{Dialect, FileInfo};
 
     use crate::AnalysisSnapshot;
 
     fn check(input: &str, expect: Expect) {
-        let (snap, file_id) =
-            AnalysisSnapshot::from_single_file(input, Dialect::Bazel, Some(APIContext::Build));
+        let (snap, file_id) = AnalysisSnapshot::from_single_file(
+            input,
+            Dialect::Bazel,
+            Some(FileInfo::Bazel {
+                api_context: APIContext::Bzl,
+                is_external: false,
+            }),
+        );
         let symbols = snap.document_symbols(file_id).unwrap().unwrap();
         let mut actual = String::new();
         for symbol in symbols {

--- a/crates/starpls_ide/src/document_symbols.rs
+++ b/crates/starpls_ide/src/document_symbols.rs
@@ -136,7 +136,7 @@ mod tests {
             input,
             Dialect::Bazel,
             Some(FileInfo::Bazel {
-                api_context: APIContext::Bzl,
+                api_context: APIContext::Build,
                 is_external: false,
             }),
         );

--- a/crates/starpls_ide/src/goto_definition.rs
+++ b/crates/starpls_ide/src/goto_definition.rs
@@ -201,15 +201,21 @@ pub(crate) fn goto_definition(
 #[cfg(test)]
 mod tests {
     use starpls_bazel::APIContext;
-    use starpls_common::Dialect;
+    use starpls_common::{Dialect, FileInfo};
     use starpls_test_util::parse_fixture;
 
     use crate::{AnalysisSnapshot, FilePosition, LocationLink};
 
     fn check_goto_definition(fixture: &str) {
         let (contents, pos, expected) = parse_fixture(fixture);
-        let (snap, file_id) =
-            AnalysisSnapshot::from_single_file(&contents, Dialect::Bazel, Some(APIContext::Bzl));
+        let (snap, file_id) = AnalysisSnapshot::from_single_file(
+            &contents,
+            Dialect::Bazel,
+            Some(FileInfo::Bazel {
+                api_context: APIContext::Bzl,
+                is_external: false,
+            }),
+        );
         let actual = snap
             .goto_definition(FilePosition { file_id, pos })
             .unwrap()

--- a/crates/starpls_ide/src/lib.rs
+++ b/crates/starpls_ide/src/lib.rs
@@ -37,6 +37,7 @@ pub(crate) struct Database {
     files: Arc<DashMap<FileId, File>>,
     loader: Arc<dyn FileLoader>,
     gcx: Arc<GlobalCtxt>,
+    prelude_file: Option<FileId>,
 }
 
 impl Database {
@@ -70,6 +71,7 @@ impl salsa::ParallelDatabase for Database {
             gcx: self.gcx.clone(),
             loader: self.loader.clone(),
             storage: self.storage.snapshot(),
+            prelude_file: self.prelude_file,
         })
     }
 }
@@ -218,6 +220,14 @@ impl starpls_hir::Db for Database {
                 Builtins::default(),
             ))
     }
+
+    fn set_bazel_prelude_file(&mut self, file_id: FileId) {
+        self.prelude_file = Some(file_id)
+    }
+
+    fn get_bazel_prelude_file(&self) -> Option<FileId> {
+        self.prelude_file
+    }
 }
 
 #[derive(Debug)]
@@ -277,6 +287,7 @@ impl Analysis {
                 gcx: Arc::new(GlobalCtxt::new(options)),
                 storage: Default::default(),
                 loader,
+                prelude_file: None,
             },
         }
     }
@@ -293,6 +304,10 @@ impl Analysis {
 
     pub fn set_builtin_defs(&mut self, builtins: Builtins, rules: Builtins) {
         self.db.set_builtin_defs(Dialect::Bazel, builtins, rules);
+    }
+
+    pub fn set_bazel_prelude_file(&mut self, file_id: FileId) {
+        self.db.set_bazel_prelude_file(file_id);
     }
 }
 


### PR DESCRIPTION
Fixes: https://github.com/withered-magic/starpls/issues/231

Adds support for the Bazel prelude, treating it as an implicitly loaded file within all `BUILD` files for the current workspace.

TODO:
- [x] Tests
- [x] Adjust `Resolver::resolve_export()` to exclude private symbols (instead of doing it in the completion provider
- [x] Only include the prelude for `BUILD` files in the current workspace (and not external files)