### PR TITLE
fix: infer current workspace name from execution_root

### DIFF
--- a/crates/starpls/src/check.rs
+++ b/crates/starpls/src/check.rs
@@ -42,6 +42,7 @@ pub(crate) fn run_check(paths: Vec<String>, output_base: Option<String>) -> anyh
         bazel_client,
         interner.clone(),
         info.workspace.clone(),
+        info.workspace_name,
         external_output_base.clone(),
         fetch_repo_sender,
         bzlmod_enabled,

--- a/crates/starpls/src/server.rs
+++ b/crates/starpls/src/server.rs
@@ -91,6 +91,7 @@ impl Server {
         };
 
         eprintln!("server: workspace root: {:?}", info.workspace);
+        eprintln!("server: workspace name: {:?}", info.workspace_name);
 
         // Determine the output base for the purpose of resolving external repositories.
         let external_output_base = info.output_base.join("external");
@@ -164,6 +165,7 @@ impl Server {
             bazel_client.clone(),
             path_interner.clone(),
             info.workspace.clone(),
+            info.workspace_name,
             external_output_base.clone(),
             task_pool_sender.clone(),
             bzlmod_enabled,


### PR DESCRIPTION
Works towards: https://github.com/withered-magic/starpls/issues/245