### PR TITLE
feat: add completion item based on type

### DIFF
--- a/crates/starpls/src/handlers/requests.rs
+++ b/crates/starpls/src/handlers/requests.rs
@@ -145,6 +145,15 @@ pub(crate) fn completion(
                     }),
                     sort_text,
                     insert_text,
+                    insert_text_format: match item.insert_text_format {
+                        Some(starpls_ide::InsertTextFormat::Snippet) => {
+                            Some(lsp_types::InsertTextFormat::SNIPPET)
+                        }
+                        Some(starpls_ide::InsertTextFormat::PlainText) => {
+                            Some(lsp_types::InsertTextFormat::PLAIN_TEXT)
+                        }
+                        _ => None,
+                    },
                     text_edit,
                     filter_text: item.filter_text,
                     ..Default::default()

--- a/crates/starpls_hir/src/lib.rs
+++ b/crates/starpls_hir/src/lib.rs
@@ -5,7 +5,9 @@ pub use crate::{
     api::*,
     def::Name,
     display::{DisplayWithDb, DisplayWithDbWrapper},
-    typeck::{builtins::BuiltinDefs, Cancelled, GlobalCtxt, InferenceOptions, Ty, TyCtxt},
+    typeck::{
+        builtins::BuiltinDefs, AttributeKind, Cancelled, GlobalCtxt, InferenceOptions, Ty, TyCtxt,
+    },
 };
 use crate::{
     def::{ExprId, Module, ModuleSourceMap},

--- a/crates/starpls_hir/src/typeck.rs
+++ b/crates/starpls_hir/src/typeck.rs
@@ -922,6 +922,22 @@ impl Param {
         }
     }
 
+    pub fn kind(&self, db: &dyn Db) -> Option<AttributeKind> {
+        let common = common_attributes_query(db);
+        let attr = match &self.0 {
+            ParamInner::BuiltinParam { parent, index } => match &parent.params(db)[*index] {
+                BuiltinFunctionParam::Simple { .. } => return None,
+                _ => return None,
+            },
+            ParamInner::RuleParam(RuleParam::Keyword { attr, .. }) => attr,
+            ParamInner::RuleParam(RuleParam::BuiltinKeyword(kind, index)) => {
+                common.get(db, kind.clone(), *index).1
+            }
+            _ => return None,
+        };
+        Some(attr.kind.clone())
+    }
+
     pub fn syntax_node_ptr(&self, db: &dyn Db) -> Option<SyntaxNodePtr> {
         match self.0 {
             ParamInner::Param { parent, index } => parent.and_then(|parent| {

--- a/crates/starpls_ide/src/lib.rs
+++ b/crates/starpls_ide/src/lib.rs
@@ -14,7 +14,8 @@ use starpls_test_util::make_test_builtins;
 
 pub use crate::{
     completions::{
-        CompletionItem, CompletionItemKind, CompletionMode, Edit, InsertReplaceEdit, TextEdit,
+        CompletionItem, CompletionItemKind, CompletionMode, Edit, InsertReplaceEdit,
+        InsertTextFormat, TextEdit,
     },
     document_symbols::{DocumentSymbol, SymbolKind, SymbolTag},
     hover::{Hover, Markup},


### PR DESCRIPTION
Replaces the existing completion items for particular types with a more ergonomic snippet.

The following have been converted to snippets:
- string parameters will be converted to `<name> = "",`, with the cursor placed in between the quotes after completion with another cursor target at the end of the line
- list parameters will be converted to `<name> = [],`, with the cursor placed in between the brackets after completion with another cursor target at the end of the line
- all other parameters will be converted to `<name> = ,`, with the cursor placed before the comma after completion with another cursor target at the end of the line
- the `load` function will be converted to `load("")`, with the cursor placed between the quotes after completion
- other function expressions will be converted to `<function_name>()` with the cursor between the parenthesis after completion

I wasn't sure how to get snippet completions for parameters for builtins, and didn't spend too much time thinking about it. If it's feasible, I can look into it further
