### PR TITLE
chore: add clippy

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -17,6 +17,9 @@ build --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
 build --output_groups=+clippy_checks
 build --@rules_rust//:clippy.toml=//:clippy.toml
 
+# Fail on warnings
+build --action_env=RUSTFLAGS=-Dwarnings
+
 build --incompatible_strict_action_env
 
 test --test_output=errors

--- a/.bazelrc
+++ b/.bazelrc
@@ -7,9 +7,15 @@ build --experimental_convenience_symlinks=ignore
 
 build --@rules_rust//rust/toolchain/channel=nightly
 
+# Check rustfmt
 build --@rules_rust//:rustfmt.toml=//:rustfmt.toml
 build --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect
 build --output_groups=+rustfmt_checks
+
+# Check clippy
+build --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
+build --output_groups=+clippy_checks
+build --@rules_rust//:clippy.toml=//:clippy.toml
 
 build --incompatible_strict_action_env
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,7 +1,10 @@
 load("@rules_rust//proto/prost:defs.bzl", "rust_prost_toolchain")
 load("@rules_rust//rust:defs.bzl", "rust_library_group")
 
-exports_files(["rustfmt.toml"])
+exports_files([
+    "clippy.toml",
+    "rustfmt.toml",
+])
 
 rust_library_group(
     name = "prost_runtime",

--- a/crates/starpls/src/convert.rs
+++ b/crates/starpls/src/convert.rs
@@ -18,7 +18,7 @@ pub(crate) fn lsp_diagnostic_from_native(
     line_index: &LineIndex,
 ) -> Option<lsp_types::Diagnostic> {
     Some(lsp_types::Diagnostic {
-        range: lsp_range_from_text_range(diagnostic.range.range, &line_index)?,
+        range: lsp_range_from_text_range(diagnostic.range.range, line_index)?,
         severity: Some(lsp_severity_from_native(diagnostic.severity)),
         code: None,
         code_description: None,

--- a/crates/starpls/src/debouncer.rs
+++ b/crates/starpls/src/debouncer.rs
@@ -20,7 +20,7 @@ impl AnalysisDebouncer {
             loop {
                 if active {
                     match source_rx.recv_timeout(duration) {
-                        Ok(file_ids) => pending_file_ids.extend(file_ids.into_iter()),
+                        Ok(file_ids) => pending_file_ids.extend(file_ids),
                         Err(RecvTimeoutError::Disconnected) => break,
                         Err(RecvTimeoutError::Timeout) => {
                             sink.send(Task::AnalysisRequested(pending_file_ids.drain().collect()))
@@ -32,7 +32,7 @@ impl AnalysisDebouncer {
                     match source_rx.recv() {
                         Ok(file_ids) => {
                             active = true;
-                            pending_file_ids.extend(file_ids.into_iter());
+                            pending_file_ids.extend(file_ids);
                         }
                         Err(RecvError) => break,
                     }

--- a/crates/starpls/src/event_loop.rs
+++ b/crates/starpls/src/event_loop.rs
@@ -320,7 +320,7 @@ fn collect_diagnostics(
     Some(
         diagnostics
             .into_iter()
-            .flat_map(|diagnostic| convert::lsp_diagnostic_from_native(diagnostic, &line_index))
+            .flat_map(|diagnostic| convert::lsp_diagnostic_from_native(diagnostic, line_index))
             .collect::<Vec<_>>(),
     )
 }

--- a/crates/starpls/src/handlers/requests.rs
+++ b/crates/starpls/src/handlers/requests.rs
@@ -62,7 +62,7 @@ pub(crate) fn goto_definition(
         snapshot
             .analysis_snapshot
             .goto_definition(FilePosition { file_id, pos })?
-            .unwrap_or_else(|| Vec::new())
+            .unwrap_or_else(Vec::new)
             .into_iter(),
     );
     Ok(Some(resp))
@@ -88,7 +88,7 @@ pub(crate) fn completion(
                 FilePosition { file_id, pos },
                 params.context.and_then(|cx| cx.trigger_character),
             )?
-            .unwrap_or_else(|| Vec::new())
+            .unwrap_or_else(Vec::new)
             .into_iter()
             .flat_map(|item| {
                 let sort_text = Some(item.sort_text());

--- a/crates/starpls/src/main.rs
+++ b/crates/starpls/src/main.rs
@@ -71,7 +71,7 @@ fn run_server(args: ServerArgs) -> anyhow::Result<()> {
 
     // Initialize the connection with server capabilities. For now, this consists
     // only of `TextDocumentSyncKind.Full`.
-    let server_capabilities = serde_json::to_value(&ServerCapabilities {
+    let server_capabilities = serde_json::to_value(ServerCapabilities {
         completion_provider: Some(CompletionOptions {
             trigger_characters: Some(make_trigger_characters(COMPLETION_TRIGGER_CHARACTERS)),
             ..Default::default()

--- a/crates/starpls/src/server.rs
+++ b/crates/starpls/src/server.rs
@@ -326,7 +326,7 @@ impl Server {
         let files = mem::take(&mut self.pending_files);
         let bazel_client = self.bazel_client.clone();
         self.is_fetching_repos = true;
-        self.fetched_repos.extend(repos.clone().into_iter());
+        self.fetched_repos.extend(repos.clone());
         self.task_pool_handle.spawn_with_sender(move |sender| {
             sender
                 .send(Task::FetchExternalRepos(FetchExternalReposProgress::Begin(

--- a/crates/starpls/src/utils.rs
+++ b/crates/starpls/src/utils.rs
@@ -117,7 +117,7 @@ where
                     origin_selection_range: origin_selection_range.and_then(|range| {
                         convert::lsp_range_from_text_range(range, source_line_index)
                     }),
-                    target_range: range.clone()?,
+                    target_range: range?,
                     target_selection_range: range?,
                     target_uri: lsp_types::Url::from_file_path(
                         snapshot

--- a/crates/starpls_bazel/src/build_language.rs
+++ b/crates/starpls_bazel/src/build_language.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 pub fn decode_rules(build_language_output: &[u8]) -> anyhow::Result<Builtins> {
-    let build_language = BuildLanguage::decode(&build_language_output[..])?;
+    let build_language = BuildLanguage::decode(build_language_output)?;
     Ok(Builtins {
         global: build_language
             .rule
@@ -21,11 +21,11 @@ pub fn decode_rules(build_language_output: &[u8]) -> anyhow::Result<Builtins> {
                  }| {
                     Value {
                         name,
-                        doc: documentation.unwrap_or_else(|| String::new()),
+                        doc: documentation.unwrap_or_else(String::new),
                         callable: Some(Callable {
                             param: attribute
                                 .into_iter()
-                                .filter(|attr| !attr.name.starts_with(&['$', ':']))
+                                .filter(|attr| !attr.name.starts_with(['$', ':']))
                                 .map(|attr| {
                                     let doc = attr.documentation().to_string();
                                     let r#type =

--- a/crates/starpls_bazel/src/env.rs
+++ b/crates/starpls_bazel/src/env.rs
@@ -32,12 +32,12 @@ struct ValueJson {
     callable: Option<CallableJson>,
 }
 
-impl Into<Value> for ValueJson {
-    fn into(self) -> Value {
+impl From<ValueJson> for Value {
+    fn from(val: ValueJson) -> Self {
         Value {
-            name: self.name,
-            doc: self.doc,
-            callable: self.callable.map(|callable| Callable {
+            name: val.name,
+            doc: val.doc,
+            callable: val.callable.map(|callable| Callable {
                 param: callable
                     .params
                     .into_iter()

--- a/crates/starpls_bazel/src/lib.rs
+++ b/crates/starpls_bazel/src/lib.rs
@@ -138,7 +138,7 @@ pub fn load_builtins(path: impl AsRef<Path>) -> anyhow::Result<Builtins> {
 }
 
 pub fn decode_builtins(data: &[u8]) -> anyhow::Result<Builtins> {
-    let builtins = Builtins::decode(&data[..])?;
+    let builtins = Builtins::decode(data)?;
     Ok(builtins)
 }
 

--- a/crates/starpls_common/src/lib.rs
+++ b/crates/starpls_common/src/lib.rs
@@ -140,7 +140,7 @@ impl Parse {
 
 #[salsa::tracked]
 pub fn parse(db: &dyn Db, file: File) -> Parse {
-    let parse = parse_module(&file.contents(db), &mut |err| {
+    let parse = parse_module(file.contents(db), &mut |err| {
         Diagnostics::push(
             db,
             Diagnostic {
@@ -164,7 +164,7 @@ struct LineIndexResult {
 
 #[salsa::tracked]
 fn line_index_query(db: &dyn Db, file: File) -> LineIndexResult {
-    let line_index = syntax_line_index(&file.contents(db));
+    let line_index = syntax_line_index(file.contents(db));
     LineIndexResult::new(db, line_index)
 }
 

--- a/crates/starpls_hir/src/api.rs
+++ b/crates/starpls_hir/src/api.rs
@@ -179,7 +179,7 @@ impl LoadItem {
     pub fn name(&self, db: &dyn Db) -> Name {
         match &module(db, self.file).load_items[self.id] {
             def::LoadItem::Direct { name, .. } | def::LoadItem::Aliased { name, .. } => {
-                Name::from_str(&name)
+                Name::from_str(name)
             }
         }
     }
@@ -344,7 +344,7 @@ impl Type {
         match self.ty.kind() {
             TyKind::BuiltinFunction(func) => Some(func.doc(db).clone()),
             TyKind::BuiltinType(ty, _) => Some(ty.doc(db).clone()),
-            TyKind::Function(func) => return func.doc(db).map(|doc| doc.to_string()),
+            TyKind::Function(func) => func.doc(db).map(|doc| doc.to_string()),
             TyKind::IntrinsicFunction(func, _) => Some(func.doc(db).clone()),
             TyKind::Rule(rule) => rule.doc.as_ref().map(Box::to_string),
             TyKind::Provider(provider) => provider.doc(db),
@@ -434,7 +434,7 @@ impl Type {
     pub fn try_as_inline_struct(&self) -> Option<Struct> {
         match self.ty.kind() {
             TyKind::Struct(strukt) => strukt.as_ref().and_then(|strukt| match strukt {
-                &typeck::Struct::Inline { ref call_expr, .. } => Some(Struct {
+                typeck::Struct::Inline { call_expr, .. } => Some(Struct {
                     call_expr: call_expr.clone(),
                 }),
                 _ => None,
@@ -484,7 +484,7 @@ impl Callable {
             )
             .intern(),
             CallableInner::BuiltinFunction(func) => TyKind::BuiltinFunction(func).intern(),
-            CallableInner::Rule(ref ty) => ty.clone().into(),
+            CallableInner::Rule(ref ty) => ty.clone(),
             CallableInner::Provider(ref provider) => TyKind::Provider(provider.clone()).intern(),
             CallableInner::ProviderRawConstructor(ref name, ref provider) => {
                 TyKind::ProviderRawConstructor(name.clone(), provider.clone()).intern()

--- a/crates/starpls_hir/src/def.rs
+++ b/crates/starpls_hir/src/def.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, ops::Index};
+use std::{collections::HashSet, fmt, ops::Index};
 
 use either::Either;
 use id_arena::{Arena, Id};
@@ -238,11 +238,7 @@ impl Expr {
         }
     }
 
-    fn walk_comp_clause_expressions(
-        &self,
-        comp_clauses: &Box<[CompClause]>,
-        mut f: impl FnMut(ExprId),
-    ) {
+    fn walk_comp_clause_expressions(&self, comp_clauses: &[CompClause], mut f: impl FnMut(ExprId)) {
         for comp_clause in comp_clauses.iter() {
             match comp_clause {
                 CompClause::For { iterable, targets } => {
@@ -443,16 +439,18 @@ impl Name {
         self.0.as_str()
     }
 
-    pub fn to_string(&self) -> String {
-        self.0.to_string()
-    }
-
     pub(crate) fn new_inline(name: &'static str) -> Self {
         Self::new(SmolStr::new_inline(name))
     }
 
     fn new(repr: SmolStr) -> Self {
         Self(repr)
+    }
+}
+
+impl fmt::Display for Name {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 

--- a/crates/starpls_hir/src/def/codeflow.rs
+++ b/crates/starpls_hir/src/def/codeflow.rs
@@ -89,6 +89,8 @@ impl<'a> CodeFlowLowerCtx<'a> {
     }
 
     fn lower_stmt(&mut self, stmt: StmtId) {
+        // Enable when collapsible matching is not experimental: https://github.com/rust-lang/rust/issues/51114
+        #![allow(clippy::collapsible_match)]
         match &self.module[stmt] {
             Stmt::Assign { lhs, rhs, .. } => {
                 self.lower_assignment_target(*lhs, *rhs);
@@ -122,7 +124,7 @@ impl<'a> CodeFlowLowerCtx<'a> {
                     }
                     Some(Either::Right(else_stmts)) => {
                         self.curr_node = pre_if_node;
-                        self.lower_stmts(&else_stmts);
+                        self.lower_stmts(else_stmts);
                         self.push_antecedent(post_if_node, self.curr_node);
                     }
                     _ => {
@@ -251,7 +253,7 @@ impl<'a> CodeFlowLowerCtx<'a> {
     }
 
     fn lower_comp_clauses(&mut self, comp_clauses: &[CompClause]) {
-        for comp_clause in comp_clauses.into_iter() {
+        for comp_clause in comp_clauses.iter() {
             match comp_clause {
                 CompClause::For { iterable, targets } => {
                     self.lower_expr(*iterable);

--- a/crates/starpls_hir/src/def/resolver.rs
+++ b/crates/starpls_hir/src/def/resolver.rs
@@ -84,7 +84,7 @@ impl<'a> Resolver<'a> {
             .filter_map(move |(scope_id, scope)| {
                 scope
                     .defs
-                    .get(&name)
+                    .get(name)
                     .map(|defs| (scope_id, scope.execution_scope, defs))
             })
             .flat_map(|(scope, execution_scope, defs)| {
@@ -192,11 +192,11 @@ impl<'a> Resolver<'a> {
         // Add names from builtins, taking the current Bazel API context into account.
         let mut add_builtins = |api_globals: &APIGlobals| {
             for (name, func) in api_globals.functions.iter() {
-                names.insert(Name::from_str(&name), ScopeDef::BuiltinFunction(*func));
+                names.insert(Name::from_str(name), ScopeDef::BuiltinFunction(*func));
             }
             for (name, type_ref) in api_globals.variables.iter() {
                 names.insert(
-                    Name::from_str(&name),
+                    Name::from_str(name),
                     ScopeDef::BuiltinVariable(type_ref.clone()),
                 );
             }
@@ -294,7 +294,7 @@ impl<'a> Resolver<'a> {
             .filter(|(range, _)| range.start() <= offset && offset <= range.end())
             .min_by_key(|(range, _)| range.len())
             .map(|(hir_range, scope)| {
-                find_nearest_predecessor(&scopes, &source_map, hir_range, offset).unwrap_or(scope)
+                find_nearest_predecessor(scopes, source_map, hir_range, offset).unwrap_or(scope)
             });
         Self::from_parts(db, file, scopes, scope)
     }

--- a/crates/starpls_hir/src/display.rs
+++ b/crates/starpls_hir/src/display.rs
@@ -111,7 +111,7 @@ impl DisplayWithDb for TyKind {
                 f.write_str("tuple[")?;
                 match tuple {
                     Tuple::Simple(tys) => {
-                        delimited(db, f, &tys, ", ")?;
+                        delimited(db, f, tys, ", ")?;
                     }
                     Tuple::Variable(ty) => {
                         ty.fmt(db, f)?;
@@ -233,7 +233,7 @@ impl DisplayWithDb for TyKind {
                             }
                             if let Some(default_value) = default_value {
                                 f.write_str(" = ")?;
-                                f.write_str(&default_value)?;
+                                f.write_str(default_value)?;
                             }
                         }
                         BuiltinFunctionParam::ArgsList { name, type_ref, .. } => {

--- a/crates/starpls_hir/src/typeck/intrinsics.rs
+++ b/crates/starpls_hir/src/typeck/intrinsics.rs
@@ -153,7 +153,7 @@ impl IntrinsicFunction {
                 .then_some(first_ty)
             })
             .cloned()
-            .unwrap_or_else(|| Ty::unknown());
+            .unwrap_or_else(Ty::unknown);
 
         Some(
             TyKind::Dict(

--- a/crates/starpls_hir/src/typeck/tests.rs
+++ b/crates/starpls_hir/src/typeck/tests.rs
@@ -96,16 +96,16 @@ fn check_infer_with_options(input: &str, expect: Expect, options: InferenceOptio
         .keys()
         .map(|ptr| (ptr, ptr.syntax_node_ptr().text_range()))
         .sorted_by(|(_, lhs), (_, rhs)| {
-            if lhs.contains_range(rhs.clone()) {
+            if lhs.contains_range(*rhs) {
                 Ordering::Greater
-            } else if rhs.contains_range(lhs.clone()) {
+            } else if rhs.contains_range(*lhs) {
                 Ordering::Less
             } else {
                 lhs.start().cmp(&rhs.start())
             }
         })
     {
-        let expr = *source_map.expr_map.get(&ptr).unwrap();
+        let expr = *source_map.expr_map.get(ptr).unwrap();
         let ty = db.gcx().with_tcx(&db, |tcx| tcx.infer_expr(file, expr));
         let node = ptr.to_node(&root);
         writeln!(
@@ -124,16 +124,16 @@ fn check_infer_with_options(input: &str, expect: Expect, options: InferenceOptio
         .keys()
         .map(|ptr| (ptr, ptr.syntax_node_ptr().text_range()))
         .sorted_by(|(_, lhs), (_, rhs)| {
-            if lhs.contains_range(rhs.clone()) {
+            if lhs.contains_range(*rhs) {
                 Ordering::Greater
-            } else if rhs.contains_range(lhs.clone()) {
+            } else if rhs.contains_range(*lhs) {
                 Ordering::Less
             } else {
                 lhs.start().cmp(&rhs.start())
             }
         })
     {
-        let param = *source_map.param_map.get(&ptr).unwrap();
+        let param = *source_map.param_map.get(ptr).unwrap();
         db.gcx().with_tcx(&db, |tcx| {
             tcx.infer_param(file, param);
         });

--- a/crates/starpls_ide/src/completions.rs
+++ b/crates/starpls_ide/src/completions.rs
@@ -12,7 +12,7 @@ use starpls_syntax::{
 
 use crate::FilePosition;
 
-const COMPLETION_MARKER: &'static str = "__STARPLS_COMPLETION_MARKER";
+const COMPLETION_MARKER: &str = "__STARPLS_COMPLETION_MARKER";
 
 const BUILTIN_TYPE_NAMES: &[&str] = &[
     "NoneType", "bool", "int", "float", "string", "bytes", "list", "tuple", "dict", "range",
@@ -391,10 +391,7 @@ impl CompletionContext {
             });
         }
 
-        if matches!(
-            trigger_character.as_ref().map(|c| c.as_str()),
-            Some("/" | ":" | "@")
-        ) {
+        if matches!(trigger_character.as_deref(), Some("/" | ":" | "@")) {
             return None;
         }
 
@@ -418,9 +415,9 @@ impl CompletionContext {
             let args = name_ref
                 .syntax()
                 .parent()
-                .and_then(|parent| ast::SimpleArgument::cast(parent))
+                .and_then(ast::SimpleArgument::cast)
                 .and_then(|arg| arg.syntax().parent())
-                .and_then(|parent| ast::Arguments::cast(parent));
+                .and_then(ast::Arguments::cast);
 
             let keyword_args = args
                 .as_ref()
@@ -435,11 +432,11 @@ impl CompletionContext {
                         })
                         .collect::<Vec<_>>()
                 })
-                .unwrap_or_else(|| Vec::new());
+                .unwrap_or_else(Vec::new);
 
             let params = args
                 .and_then(|arg| arg.syntax().parent())
-                .and_then(|parent| ast::CallExpr::cast(parent))
+                .and_then(ast::CallExpr::cast)
                 .and_then(|expr| expr.callee())
                 .and_then(|expr| sema.type_of_expr(file, &expr))
                 .map(|ty| {
@@ -455,7 +452,7 @@ impl CompletionContext {
                         })
                         .collect()
                 })
-                .unwrap_or_else(|| vec![]);
+                .unwrap_or_else(std::vec::Vec::new);
 
             let scope = sema.scope_for_offset(file, pos);
 
@@ -487,12 +484,12 @@ impl CompletionContext {
             let parent = name.syntax().parent()?;
             CompletionAnalysis::Name(if let Some(expr) = ast::DotExpr::cast(parent) {
                 NameContext::Dot {
-                    receiver_ty: sema.type_of_expr(file, &expr.expr()?.into())?,
+                    receiver_ty: sema.type_of_expr(file, &expr.expr()?)?,
                 }
             } else {
                 NameContext::Def
             })
-        } else if let Some(_) = ast::NamedType::cast(parent) {
+        } else if ast::NamedType::cast(parent).is_some() {
             CompletionAnalysis::Type
         } else {
             return None;

--- a/crates/starpls_ide/src/diagnostics.rs
+++ b/crates/starpls_ide/src/diagnostics.rs
@@ -20,6 +20,6 @@ pub(crate) fn diagnostics(db: &Database, file_id: FileId) -> Vec<Diagnostic> {
     // is really wrong with the file being analyzed.
     diagnostics_for_file(db, file)
         .take(128)
-        .chain(diagnostics.into_iter())
+        .chain(diagnostics)
         .collect()
 }

--- a/crates/starpls_ide/src/document_symbols.rs
+++ b/crates/starpls_ide/src/document_symbols.rs
@@ -71,7 +71,7 @@ pub(crate) fn document_symbols(db: &Database, file_id: FileId) -> Option<Vec<Doc
                     _ => return None,
                 },
                 tags: None,
-                range: range.clone(),
+                range,
                 selection_range: range,
                 children: None,
             })
@@ -115,7 +115,7 @@ fn add_target_symbols(db: &Database, file: File, acc: &mut Vec<DocumentSymbol>) 
             detail: None,
             kind: SymbolKind::Variable,
             tags: None,
-            range: range.clone(),
+            range,
             selection_range: range,
             children: None,
         })

--- a/crates/starpls_ide/src/goto_definition.rs
+++ b/crates/starpls_ide/src/goto_definition.rs
@@ -36,8 +36,8 @@ pub(crate) fn goto_definition(
                         let range = def.value.syntax_node_ptr(db, def.file)?.text_range();
                         Some(LocationLink::Local {
                             origin_selection_range: None,
-                            target_range: range.clone(),
-                            target_selection_range: range.clone(),
+                            target_range: range,
+                            target_selection_range: range,
                             target_file_id: def.file.id(db),
                         })
                     }
@@ -73,7 +73,7 @@ pub(crate) fn goto_definition(
                             let range = name.syntax().text_range();
                             vec![LocationLink::Local {
                                 origin_selection_range: None,
-                                target_range: range.clone(),
+                                target_range: range,
                                 target_selection_range: range,
                                 target_file_id: struct_call_expr.file.id(db),
                             }]
@@ -128,7 +128,7 @@ pub(crate) fn goto_definition(
         let range = def.value.syntax_node_ptr(db, def.file)?.text_range();
         return Some(vec![LocationLink::Local {
             origin_selection_range: None,
-            target_range: range.clone(),
+            target_range: range,
             target_selection_range: range,
             target_file_id: def.file.id(db),
         }]);
@@ -175,7 +175,7 @@ pub(crate) fn goto_definition(
                                             })
                                             .and_then(|expr| match expr.kind() {
                                                 ast::LiteralKind::String(s) => {
-                                                    s.value().map(|value| &*value == target)
+                                                    s.value().map(|value| *value == target)
                                                 }
                                                 _ => None,
                                             })
@@ -187,7 +187,7 @@ pub(crate) fn goto_definition(
                 let range = call_expr.syntax().text_range();
                 Some(vec![LocationLink::Local {
                     origin_selection_range: Some(token.text_range()),
-                    target_range: range.clone(),
+                    target_range: range,
                     target_selection_range: range,
                     target_file_id: build_file_id,
                 }])

--- a/crates/starpls_ide/src/hover.rs
+++ b/crates/starpls_ide/src/hover.rs
@@ -70,7 +70,7 @@ pub(crate) fn hover(db: &Database, FilePosition { file_id, pos }: FilePosition) 
         let name_token = name.name()?;
         let name_text = name_token.text();
         if let Some(expr) = ast::DotExpr::cast(parent.clone()) {
-            let ty = sema.type_of_expr(file, &expr.expr()?.into())?;
+            let ty = sema.type_of_expr(file, &expr.expr()?)?;
             let fields = ty.fields(db);
             let (field, field_ty) = fields.into_iter().find_map(|(field, ty)| {
                 if field.name(db).as_str() == name_text {
@@ -122,9 +122,9 @@ pub(crate) fn hover(db: &Database, FilePosition { file_id, pos }: FilePosition) 
             let call = arg
                 .syntax()
                 .parent()
-                .and_then(|parent| ast::Arguments::cast(parent))
+                .and_then(ast::Arguments::cast)
                 .and_then(|args| args.syntax().parent())
-                .and_then(|parent| ast::CallExpr::cast(parent))?;
+                .and_then(ast::CallExpr::cast)?;
             let func = sema.resolve_call_expr(file, &call)?;
             let (name, param, ty) = func.params(db).into_iter().find_map(|(param, ty)| {
                 let name = param.name(db)?;

--- a/crates/starpls_ide/src/line_index.rs
+++ b/crates/starpls_ide/src/line_index.rs
@@ -3,7 +3,7 @@ use starpls_syntax::LineIndex;
 
 use crate::Database;
 
-pub(crate) fn line_index<'a>(db: &'a Database, file_id: FileId) -> Option<&'a LineIndex> {
+pub(crate) fn line_index(db: &Database, file_id: FileId) -> Option<&LineIndex> {
     let file = db.get_file(file_id)?;
     Some(starpls_common::line_index(db, file))
 }

--- a/crates/starpls_ide/src/signature_help.rs
+++ b/crates/starpls_ide/src/signature_help.rs
@@ -105,14 +105,14 @@ pub(crate) fn signature_help(
 
     let is_rule_or_tag = func.is_rule() || func.is_tag();
     if is_rule_or_tag {
-        label.push_str("*");
+        label.push('*');
     }
 
     for (index, param_label) in param_labels.iter().enumerate() {
         if index > 0 || is_rule_or_tag {
             label.push_str(", ");
         }
-        label.push_str(&param_label);
+        label.push_str(param_label);
     }
 
     label.push_str(") -> ");

--- a/crates/starpls_lexer/src/lib.rs
+++ b/crates/starpls_lexer/src/lib.rs
@@ -740,42 +740,27 @@ impl Cursor<'_> {
 
     fn eat_octal_digits(&mut self) -> bool {
         let mut has_digits = false;
-        loop {
-            match self.first() {
-                '0'..='7' => {
-                    has_digits = true;
-                    self.bump();
-                }
-                _ => break,
-            }
+        while let '0'..='7' = self.first() {
+            has_digits = true;
+            self.bump();
         }
         has_digits
     }
 
     fn eat_decimal_digits(&mut self) -> bool {
         let mut has_digits = false;
-        loop {
-            match self.first() {
-                '0'..='9' => {
-                    has_digits = true;
-                    self.bump();
-                }
-                _ => break,
-            }
+        while let '0'..='9' = self.first() {
+            has_digits = true;
+            self.bump();
         }
         has_digits
     }
 
     fn eat_hexadecimal_digits(&mut self) -> bool {
         let mut has_digits = false;
-        loop {
-            match self.first() {
-                '0'..='9' | 'a'..='f' | 'A'..='F' => {
-                    has_digits = true;
-                    self.bump();
-                }
-                _ => break,
-            }
+        while let '0'..='9' | 'a'..='f' | 'A'..='F' = self.first() {
+            has_digits = true;
+            self.bump();
         }
         has_digits
     }

--- a/crates/starpls_lexer/src/tests.rs
+++ b/crates/starpls_lexer/src/tests.rs
@@ -3,9 +3,10 @@ use expect_test::{expect, Expect};
 use super::*;
 
 fn check_lexing(input: &str, expect: Expect) {
-    let actual: String = tokenize(input)
-        .map(|token| format!("{:?}\n", token))
-        .collect();
+    let actual: String = tokenize(input).fold(String::new(), |mut output, token| {
+        output.push_str(&format!("{:?}\n", token));
+        output
+    });
     expect.assert_eq(&actual);
 }
 

--- a/crates/starpls_lexer/src/unescape.rs
+++ b/crates/starpls_lexer/src/unescape.rs
@@ -285,7 +285,7 @@ fn scan_unicode_escape(chars: &mut Chars<'_>) -> Result<char, EscapeError> {
         }
     }
 
-    char::from_u32(value).ok_or_else(|| {
+    char::from_u32(value).ok_or({
         if value > 0x10FFFF {
             EscapeError::OutOfRangeUnicodeEscape
         } else {

--- a/crates/starpls_parser/src/grammar/expressions.rs
+++ b/crates/starpls_parser/src/grammar/expressions.rs
@@ -209,10 +209,8 @@ fn slice_or_index_expr(p: &mut Parser, m: Marker) -> CompletedMarker {
         if p.at_kinds(EXPR_START) {
             test(p);
         }
-        if p.eat(T![:]) {
-            if p.at_kinds(EXPR_START) {
-                test(p);
-            }
+        if p.eat(T![:]) && p.at_kinds(EXPR_START) {
+            test(p);
         }
     }
     if !p.eat(T![']']) {

--- a/crates/starpls_parser/src/tests.rs
+++ b/crates/starpls_parser/src/tests.rs
@@ -95,13 +95,10 @@ fn collect_test_cases(dir: &'static str) -> Result<Vec<TestCase>, Box<dyn error:
                 continue;
             }
         };
-        match filter {
-            Some(ref filter) => {
-                if !test_name.contains(filter) {
-                    continue;
-                }
+        if let Some(ref filter) = filter {
+            if !test_name.contains(filter) {
+                continue;
             }
-            None => (),
         }
 
         // For a Starlark source file `source.star`, the corresponding expect file is `source.rast`.

--- a/crates/starpls_parser/src/text.rs
+++ b/crates/starpls_parser/src/text.rs
@@ -140,6 +140,10 @@ impl<'a> StrWithTokens<'a> {
         (self.token_start[pos], self.token_start[end])
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.token_kinds.is_empty()
+    }
+
     pub fn len(&self) -> usize {
         self.token_kinds.len()
     }

--- a/crates/starpls_syntax/src/ast.rs
+++ b/crates/starpls_syntax/src/ast.rs
@@ -722,9 +722,7 @@ ast_node! {
 impl Suite {
     /// Only call this if you know the parent suite belongs to a function.
     pub fn type_comment(&self) -> Option<TypeComment> {
-        self.syntax()
-            .first_child()
-            .and_then(|node| TypeComment::cast(node))
+        self.syntax().first_child().and_then(TypeComment::cast)
     }
 }
 
@@ -1204,17 +1202,16 @@ ast_token! {
 impl Int {
     pub fn value(&self) -> Option<u64> {
         let text = self.syntax.text();
-        if text.starts_with("0") {
-            return Some(if text.len() == 1 {
-                0
-            } else {
-                u64::from_str_radix(&text[1..], 8).ok()?
-            });
+        if text.starts_with('0') && text.len() == 1 {
+            return Some(0);
         }
-        if text.starts_with("0x") {
-            return u64::from_str_radix(&text[2..], 16).ok();
+        if let Some(suffix) = text.strip_prefix('0') {
+            return u64::from_str_radix(suffix, 8).ok();
         }
-        return u64::from_str_radix(text, 10).ok();
+        if let Some(suffix) = text.strip_prefix("0x") {
+            return u64::from_str_radix(suffix, 16).ok();
+        }
+        text.parse::<u64>().ok()
     }
 }
 

--- a/crates/starpls_syntax/src/parser.rs
+++ b/crates/starpls_syntax/src/parser.rs
@@ -5,7 +5,7 @@ use starpls_parser::{parse, parse_type_list, StrStep, StrWithTokens, SyntaxKind:
 
 use crate::{LineIndex, Module, StarlarkLanguage, SyntaxNode};
 
-const TYPE_COMMENT_PREFIX_STR: &'static str = "# type: ";
+const TYPE_COMMENT_PREFIX_STR: &str = "# type: ";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SyntaxError {

--- a/xtask/src/update_parser_test_data.rs
+++ b/xtask/src/update_parser_test_data.rs
@@ -41,10 +41,8 @@ fn extract_comment_blocks(text: &str) -> Vec<CommentBlock> {
     // at which point the intermediate block's contents are pushed to our accumulator, and the intermediate
     // block is reset.
     for line in lines {
-        if line.starts_with(comment_prefix) {
-            current_block
-                .lines
-                .push(line[comment_prefix.len()..].to_string());
+        if let Some(comment_content) = line.strip_prefix(comment_prefix) {
+            current_block.lines.push(comment_content.to_string());
         } else if !current_block.lines.is_empty() {
             blocks.push(mem::take(&mut current_block));
         }
@@ -117,7 +115,7 @@ pub(crate) fn run(filters: &[String]) -> anyhow::Result<()> {
     let source_dir = project_root().join("crates/starpls_parser/src/grammar");
 
     // Collect tests from all `*.rs` files in the `src` directory.
-    for entry in fs::read_dir(&source_dir)? {
+    for entry in fs::read_dir(source_dir)? {
         let entry = entry?;
         let path = entry.path();
 


### PR DESCRIPTION
Adds [clippy](https://doc.rust-lang.org/stable/clippy/index.html) as a linter and fixes all breakages of rules. Also makes clippy run [on bazel build](https://bazelbuild.github.io/rules_rust/rust_clippy.html).
