### PR TITLE
fix: support escaped newlines within string literals

### DIFF
--- a/crates/starpls_lexer/src/lib.rs
+++ b/crates/starpls_lexer/src/lib.rs
@@ -810,7 +810,10 @@ impl Cursor<'_> {
                         return (true, triple_quoted);
                     }
                 }
-                '\\' if self.first() == '\\' || self.first() == closing_quote => {
+                '\\' if self.first() == '\\'
+                    || self.first() == closing_quote
+                    || self.first() == '\n' =>
+                {
                     // Bump again to skip the escaped character.
                     self.bump();
                 }

--- a/crates/starpls_lexer/src/tests.rs
+++ b/crates/starpls_lexer/src/tests.rs
@@ -797,3 +797,20 @@ foo(3 + \
         "#]],
     )
 }
+
+#[test]
+fn test_escaped_newline_in_string() {
+    check_lexing(
+        r#"
+greeting = "Hello, \
+world!""#,
+        expect![[r#"
+            Token { kind: Newline, len: 1 }
+            Token { kind: Ident, len: 8 }
+            Token { kind: Whitespace, len: 1 }
+            Token { kind: Eq, len: 1 }
+            Token { kind: Whitespace, len: 1 }
+            Token { kind: Literal { kind: Str { terminated: true, triple_quoted: false } }, len: 17 }
+        "#]],
+    );
+}


### PR DESCRIPTION
Fixes: https://github.com/withered-magic/starpls/issues/279

Support escaped newlines within string literals as described [here](https://github.com/bazelbuild/starlark/blob/master/spec.md#string-escapes).