### PR TITLE
feat: provide completions for labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,55 @@ def _impl(ctx):
 
 then you'll get autocomplete suggestions for the attributes on `ctx`, like `ctx.actions`, `ctx.attr`, and so on!
 
+## Experimental features
+
+Starpls has a number of experimental features that can be enabled via command-line arguments:
+
+### `--experimental_infer_ctx_attributes`
+
+Infer attributes on a rule implementation function's `ctx` parameter.
+
+```python
+def _foo_impl(ctx):
+    ctx.attr.bar # type: int
+
+foo = rule(
+    implementation = _foo_impl,
+    attrs = {
+        "bar": attr.int(),
+    },
+)
+```
+
+### `--experimental_use_code_flow_analysis`
+
+Use code flow analysis to determine additional information about types.
+
+```python
+if cond:
+    x = 1
+else:
+    x = "abc"
+
+x # type: int | string
+```
+
+### `--experimental_enable_label_completions`
+
+Enables completions for labels within Bazel files. For example, given the following `BUILD.bazel` file at the repository root:
+
+```python
+my_rule(
+    name = "foo"
+)
+
+my_rule(
+    name = "bar",
+    srcs = ["//:"],
+              # ^ ... If the cursor is here, "foo" will be suggested.
+)
+```
+
 ## Roadmap
 
 - Parsing

--- a/crates/starpls/src/document.rs
+++ b/crates/starpls/src/document.rs
@@ -652,6 +652,16 @@ impl FileLoader for DefaultFileLoader {
             }
         }
     }
+
+    fn resolve_build_file(&self, file_id: FileId) -> Option<String> {
+        let path = self.interner.lookup_by_file_id(file_id);
+        let path = path.strip_prefix(&self.workspace).ok()?;
+        if path.file_name()?.to_string_lossy() == "BUILD.bazel" {
+            Some(path.parent()?.to_string_lossy().to_string())
+        } else {
+            None
+        }
+    }
 }
 
 fn read_dir_packages_and_targets(

--- a/crates/starpls/src/handlers/notifications.rs
+++ b/crates/starpls/src/handlers/notifications.rs
@@ -55,6 +55,10 @@ pub(crate) fn did_save_text_document(
         match path.file_name().and_then(|file_name| file_name.to_str()) {
             Some("MODULE.bazel" | "WORKSPACE" | "WORKSPACE.bazel" | "WORKSPACE.bzlmod") => {}
             Some(file_name) if file_name.ends_with(".MODULE.bazel") => {}
+            Some("BUILD.bazel") => {
+                server.refresh_all_workspace_targets();
+                return Ok(());
+            }
             _ => return Ok(()),
         }
         server.bazel_client.clear_repo_mappings();

--- a/crates/starpls/src/handlers/requests.rs
+++ b/crates/starpls/src/handlers/requests.rs
@@ -84,7 +84,7 @@ pub(crate) fn completion(
     Ok(Some(
         snapshot
             .analysis_snapshot
-            .completion(
+            .completions(
                 FilePosition { file_id, pos },
                 params.context.and_then(|cx| cx.trigger_character),
             )?

--- a/crates/starpls/src/main.rs
+++ b/crates/starpls/src/main.rs
@@ -56,12 +56,21 @@ pub(crate) struct ServerArgs {
     /// Path to the Bazel binary.
     #[clap(long = "bazel_path")]
     bazel_path: Option<String>,
+
     /// Infer attributes on a rule implementation function's context parameter.
     #[clap(long = "experimental_infer_ctx_attributes", default_value_t = false)]
     infer_ctx_attributes: bool,
-    /// Enable code-flow analysis during typechecking.
+
+    /// Use code-flow analysis during typechecking.
     #[clap(long = "experimental_use_code_flow_analysis", default_value_t = false)]
     use_code_flow_analysis: bool,
+
+    /// Enable completions for labels for targets in the current workspace.
+    #[clap(
+        long = "experimental_enable_label_completions",
+        default_value_t = false
+    )]
+    enable_label_completions: bool,
 }
 
 fn main() -> anyhow::Result<()> {

--- a/crates/starpls/src/server.rs
+++ b/crates/starpls/src/server.rs
@@ -391,7 +391,7 @@ impl Server {
     }
 
     pub(crate) fn refresh_all_workspace_targets(&mut self) {
-        if self.is_refreshing_all_workspace_targets {
+        if self.is_refreshing_all_workspace_targets || !self.config.args.enable_label_completions {
             return;
         }
 

--- a/crates/starpls_bazel/src/client.rs
+++ b/crates/starpls_bazel/src/client.rs
@@ -31,6 +31,7 @@ pub trait BazelClient: Send + Sync + 'static {
     fn clear_repo_mappings(&self);
     fn null_query_external_repo_targets(&self, repo: &str) -> anyhow::Result<()>;
     fn repo_mapping_keys(&self, from_repo: &str) -> anyhow::Result<Vec<String>>;
+    fn query_all_workspace_targets(&self) -> anyhow::Result<Vec<String>>;
 }
 
 pub struct BazelCLI {
@@ -173,6 +174,15 @@ impl BazelClient for BazelCLI {
             .write()
             .insert(from_repo.to_string(), mapping);
         Ok(keys)
+    }
+
+    fn query_all_workspace_targets(&self) -> anyhow::Result<Vec<String>> {
+        let output = self.run_command(&["query", "kind('.* rule', ...)"])?;
+        let targets = str::from_utf8(&output)?
+            .lines()
+            .map(|line| line.to_string())
+            .collect();
+        Ok(targets)
     }
 }
 

--- a/crates/starpls_common/src/lib.rs
+++ b/crates/starpls_common/src/lib.rs
@@ -96,6 +96,8 @@ pub trait Db: salsa::DbWithJar<Jar> {
         dialect: Dialect,
         from: FileId,
     ) -> anyhow::Result<Option<ResolvedPath>>;
+
+    fn resolve_build_file(&self, file_id: FileId) -> Option<String>;
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/crates/starpls_hir/src/lib.rs
+++ b/crates/starpls_hir/src/lib.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use starpls_bazel::Builtins;
 use starpls_common::parse;
 use starpls_common::Dialect;
@@ -77,6 +79,8 @@ pub trait Db: salsa::DbWithJar<Jar> + starpls_common::Db {
     fn get_builtin_defs(&self, dialect: &Dialect) -> BuiltinDefs;
     fn set_bazel_prelude_file(&mut self, file_id: FileId);
     fn get_bazel_prelude_file(&self) -> Option<FileId>;
+    fn set_all_workspace_targets(&mut self, targets: Vec<String>);
+    fn get_all_workspace_targets(&self) -> Arc<Vec<String>>;
 }
 
 #[salsa::tracked]

--- a/crates/starpls_hir/src/test_database.rs
+++ b/crates/starpls_hir/src/test_database.rs
@@ -24,6 +24,7 @@ pub(crate) struct TestDatabase {
     storage: salsa::Storage<Self>,
     files: Arc<DashMap<FileId, File>>,
     prelude_file: Option<FileId>,
+    all_workspace_targets: Arc<Vec<String>>,
     pub(crate) gcx: Arc<GlobalContext>,
 }
 
@@ -118,6 +119,14 @@ impl crate::Db for TestDatabase {
 
     fn gcx(&self) -> &GlobalContext {
         &self.gcx
+    }
+
+    fn set_all_workspace_targets(&mut self, targets: Vec<String>) {
+        self.all_workspace_targets = Arc::new(targets)
+    }
+
+    fn get_all_workspace_targets(&self) -> Arc<Vec<String>> {
+        Arc::clone(&self.all_workspace_targets)
     }
 }
 

--- a/crates/starpls_hir/src/test_database.rs
+++ b/crates/starpls_hir/src/test_database.rs
@@ -84,6 +84,10 @@ impl starpls_common::Db for TestDatabase {
     ) -> anyhow::Result<Option<ResolvedPath>> {
         Ok(None)
     }
+
+    fn resolve_build_file(&self, _file_id: FileId) -> Option<String> {
+        None
+    }
 }
 
 impl crate::Db for TestDatabase {

--- a/crates/starpls_ide/src/completions.rs
+++ b/crates/starpls_ide/src/completions.rs
@@ -29,7 +29,7 @@ const BUILTIN_TYPE_NAMES: &[&str] = &[
     "NoneType", "bool", "int", "float", "string", "bytes", "list", "tuple", "dict", "range",
 ];
 
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct CompletionItem {
     pub label: String,
     pub kind: CompletionItemKind,
@@ -44,32 +44,32 @@ impl CompletionItem {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Edit {
     TextEdit(TextEdit),
     InsertReplaceEdit(InsertReplaceEdit),
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct TextEdit {
     pub range: TextRange,
     pub new_text: String,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct InsertReplaceEdit {
     pub new_text: String,
     pub insert: TextRange,
     pub replace: TextRange,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum CompletionMode {
     InsertText(String),
     TextEdit(Edit),
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum CompletionItemKind {
     Function,
     Field,
@@ -83,7 +83,7 @@ pub enum CompletionItemKind {
 }
 
 #[repr(u16)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 enum CompletionRelevance {
     Parameter,
     VariableOrKeyword,
@@ -570,10 +570,213 @@ impl CompletionContext {
 }
 
 fn strip_last_package_or_target(label: &str) -> &str {
-    // Prioritize finding ':' over '/'. This is required to handle labels like "//:node_modules/foo" correctly.
     if let Some(index) = label.rfind(&[':', '/']) {
         &label[..index + 1]
     } else {
         label
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fmt::Write;
+
+    use expect_test::expect;
+    use expect_test::Expect;
+    use starpls_bazel::APIContext;
+    use starpls_common::Dialect;
+    use starpls_common::FileInfo;
+    use starpls_test_util::Fixture;
+
+    use crate::completions::CompletionRelevance;
+    use crate::AnalysisSnapshot;
+    use crate::CompletionItemKind;
+    use crate::FilePosition;
+
+    fn check_completions(fixture: &str, expect: Expect) {
+        check_completions_with_options(fixture, false, expect);
+    }
+
+    fn check_completions_with_options(
+        fixture: &str,
+        include_builtins_and_keywords: bool,
+        expect: Expect,
+    ) {
+        let fixture = Fixture::parse(fixture);
+        let (snap, file_id) = AnalysisSnapshot::from_single_file(
+            &fixture.contents,
+            Dialect::Bazel,
+            Some(FileInfo::Bazel {
+                api_context: APIContext::Bzl,
+                is_external: false,
+            }),
+        );
+
+        let completions = snap
+            .completions(
+                FilePosition {
+                    file_id,
+                    pos: fixture.cursor_pos,
+                },
+                Some("".to_string()),
+            )
+            .unwrap()
+            .unwrap();
+
+        let mut completions = completions
+            .into_iter()
+            .filter(|item| {
+                include_builtins_and_keywords
+                    || (item.relevance != CompletionRelevance::Builtin
+                        && item.kind != CompletionItemKind::Keyword)
+            })
+            .collect::<Vec<_>>();
+        completions.sort_by(|item1, item2| item1.label.cmp(&item2.label));
+
+        let expected = completions
+            .into_iter()
+            .fold(String::new(), |mut acc, item| {
+                writeln!(acc, "{:?}", item).unwrap();
+                acc
+            });
+
+        expect.assert_eq(&expected);
+    }
+
+    #[test]
+    fn test_empty() {
+        check_completions_with_options(
+            r#"
+$0
+"#,
+            true,
+            expect![[r#"
+                CompletionItem { label: "False", kind: Keyword, mode: None, filter_text: None, relevance: VariableOrKeyword }
+                CompletionItem { label: "None", kind: Keyword, mode: None, filter_text: None, relevance: VariableOrKeyword }
+                CompletionItem { label: "True", kind: Keyword, mode: None, filter_text: None, relevance: VariableOrKeyword }
+                CompletionItem { label: "abs", kind: Function, mode: None, filter_text: None, relevance: Builtin }
+                CompletionItem { label: "all", kind: Function, mode: None, filter_text: None, relevance: Builtin }
+                CompletionItem { label: "any", kind: Function, mode: None, filter_text: None, relevance: Builtin }
+                CompletionItem { label: "attr", kind: Module, mode: None, filter_text: None, relevance: Builtin }
+                CompletionItem { label: "bool", kind: Function, mode: None, filter_text: None, relevance: Builtin }
+                CompletionItem { label: "bytes", kind: Function, mode: None, filter_text: None, relevance: Builtin }
+                CompletionItem { label: "def", kind: Keyword, mode: None, filter_text: None, relevance: VariableOrKeyword }
+                CompletionItem { label: "dict", kind: Function, mode: None, filter_text: None, relevance: Builtin }
+                CompletionItem { label: "dir", kind: Function, mode: None, filter_text: None, relevance: Builtin }
+                CompletionItem { label: "enumerate", kind: Function, mode: None, filter_text: None, relevance: Builtin }
+                CompletionItem { label: "fail", kind: Function, mode: None, filter_text: None, relevance: Builtin }
+                CompletionItem { label: "float", kind: Function, mode: None, filter_text: None, relevance: Builtin }
+                CompletionItem { label: "for", kind: Keyword, mode: None, filter_text: None, relevance: VariableOrKeyword }
+                CompletionItem { label: "getattr", kind: Function, mode: None, filter_text: None, relevance: Builtin }
+                CompletionItem { label: "hasattr", kind: Function, mode: None, filter_text: None, relevance: Builtin }
+                CompletionItem { label: "hash", kind: Function, mode: None, filter_text: None, relevance: Builtin }
+                CompletionItem { label: "if", kind: Keyword, mode: None, filter_text: None, relevance: VariableOrKeyword }
+                CompletionItem { label: "int", kind: Function, mode: None, filter_text: None, relevance: Builtin }
+                CompletionItem { label: "lambda", kind: Keyword, mode: None, filter_text: None, relevance: VariableOrKeyword }
+                CompletionItem { label: "len", kind: Function, mode: None, filter_text: None, relevance: Builtin }
+                CompletionItem { label: "licenses", kind: Function, mode: None, filter_text: None, relevance: Builtin }
+                CompletionItem { label: "list", kind: Function, mode: None, filter_text: None, relevance: Builtin }
+                CompletionItem { label: "load", kind: Keyword, mode: None, filter_text: None, relevance: VariableOrKeyword }
+                CompletionItem { label: "max", kind: Function, mode: None, filter_text: None, relevance: Builtin }
+                CompletionItem { label: "min", kind: Function, mode: None, filter_text: None, relevance: Builtin }
+                CompletionItem { label: "module_extension", kind: Function, mode: None, filter_text: None, relevance: Builtin }
+                CompletionItem { label: "package", kind: Function, mode: None, filter_text: None, relevance: Builtin }
+                CompletionItem { label: "pass", kind: Keyword, mode: None, filter_text: None, relevance: VariableOrKeyword }
+                CompletionItem { label: "print", kind: Function, mode: None, filter_text: None, relevance: Builtin }
+                CompletionItem { label: "provider", kind: Function, mode: None, filter_text: None, relevance: Builtin }
+                CompletionItem { label: "range", kind: Function, mode: None, filter_text: None, relevance: Builtin }
+                CompletionItem { label: "repository_rule", kind: Function, mode: None, filter_text: None, relevance: Builtin }
+                CompletionItem { label: "repr", kind: Function, mode: None, filter_text: None, relevance: Builtin }
+                CompletionItem { label: "reversed", kind: Function, mode: None, filter_text: None, relevance: Builtin }
+                CompletionItem { label: "rule", kind: Function, mode: None, filter_text: None, relevance: Builtin }
+                CompletionItem { label: "sorted", kind: Function, mode: None, filter_text: None, relevance: Builtin }
+                CompletionItem { label: "str", kind: Function, mode: None, filter_text: None, relevance: Builtin }
+                CompletionItem { label: "struct", kind: Function, mode: None, filter_text: None, relevance: Builtin }
+                CompletionItem { label: "tag_class", kind: Function, mode: None, filter_text: None, relevance: Builtin }
+                CompletionItem { label: "tuple", kind: Function, mode: None, filter_text: None, relevance: Builtin }
+                CompletionItem { label: "type", kind: Function, mode: None, filter_text: None, relevance: Builtin }
+                CompletionItem { label: "zip", kind: Function, mode: None, filter_text: None, relevance: Builtin }
+            "#]],
+        );
+    }
+
+    #[test]
+    fn test_parameters() {
+        check_completions(
+            r#"
+abc = 1
+def foo(x, y):
+    pass
+    x + $0
+"#,
+            expect![[r#"
+                CompletionItem { label: "abc", kind: Variable, mode: None, filter_text: None, relevance: VariableOrKeyword }
+                CompletionItem { label: "foo", kind: Function, mode: None, filter_text: None, relevance: VariableOrKeyword }
+                CompletionItem { label: "x", kind: Variable, mode: None, filter_text: None, relevance: VariableOrKeyword }
+                CompletionItem { label: "y", kind: Variable, mode: None, filter_text: None, relevance: VariableOrKeyword }
+            "#]],
+        );
+    }
+
+    #[test]
+    fn test_arguments() {
+        check_completions(
+            r#"
+def foo(x, y):
+    pass
+
+foo(
+    $0
+)
+"#,
+            expect![[r#"
+                CompletionItem { label: "foo", kind: Function, mode: None, filter_text: None, relevance: VariableOrKeyword }
+                CompletionItem { label: "x=", kind: Variable, mode: Some(InsertText("x = ")), filter_text: None, relevance: Parameter }
+                CompletionItem { label: "y=", kind: Variable, mode: Some(InsertText("y = ")), filter_text: None, relevance: Parameter }
+            "#]],
+        );
+    }
+
+    #[test]
+    fn test_variables() {
+        check_completions(
+            r#"
+x = 1
+y = 2
+$0
+"#,
+            expect![[r#"
+                CompletionItem { label: "x", kind: Variable, mode: None, filter_text: None, relevance: VariableOrKeyword }
+                CompletionItem { label: "y", kind: Variable, mode: None, filter_text: None, relevance: VariableOrKeyword }
+            "#]],
+        );
+    }
+
+    #[test]
+    fn test_fields() {
+        check_completions(
+            r#"
+foo = struct(x = 1, y = 2)
+foo.$0
+"#,
+            expect![[r#"
+                CompletionItem { label: "x", kind: Field, mode: None, filter_text: None, relevance: VariableOrKeyword }
+                CompletionItem { label: "y", kind: Field, mode: None, filter_text: None, relevance: VariableOrKeyword }
+            "#]],
+        );
+    }
+
+    #[test]
+    fn test_dict_keys() {
+        check_completions(
+            r#"
+d = {"a": 1, "b": 2}
+d["$0"]
+"#,
+            expect![[r#"
+                CompletionItem { label: "a", kind: Constant, mode: None, filter_text: None, relevance: VariableOrKeyword }
+                CompletionItem { label: "b", kind: Constant, mode: None, filter_text: None, relevance: VariableOrKeyword }
+            "#]],
+        );
     }
 }

--- a/crates/starpls_ide/src/hover.rs
+++ b/crates/starpls_ide/src/hover.rs
@@ -422,4 +422,28 @@ foo.b$0ar
             "#]],
         );
     }
+
+    #[test]
+    fn check_rule_attr() {
+        check_hover(
+            r#"
+foo = rule(
+    attrs = {
+        "bar": attr.string(doc = "The bar attr"),
+    },
+)
+
+foo(
+    name = "foo",
+    b$0ar = "bar",
+)
+"#,
+            expect![[r#"
+                ```python
+                (parameter) bar: string
+                ```
+                The bar attr  
+            "#]],
+        );
+    }
 }

--- a/crates/starpls_ide/src/lib.rs
+++ b/crates/starpls_ide/src/lib.rs
@@ -62,6 +62,7 @@ pub(crate) struct Database {
     loader: Arc<dyn FileLoader>,
     gcx: Arc<GlobalContext>,
     prelude_file: Option<FileId>,
+    all_workspace_targets: Arc<Vec<String>>,
 }
 
 impl Database {
@@ -96,6 +97,7 @@ impl salsa::ParallelDatabase for Database {
             loader: self.loader.clone(),
             storage: self.storage.snapshot(),
             prelude_file: self.prelude_file,
+            all_workspace_targets: self.all_workspace_targets.clone(),
         })
     }
 }
@@ -223,6 +225,14 @@ impl starpls_hir::Db for Database {
         self.prelude_file
     }
 
+    fn set_all_workspace_targets(&mut self, targets: Vec<String>) {
+        self.all_workspace_targets = Arc::new(targets)
+    }
+
+    fn get_all_workspace_targets(&self) -> Arc<Vec<String>> {
+        Arc::clone(&self.all_workspace_targets)
+    }
+
     fn gcx(&self) -> &GlobalContext {
         &self.gcx
     }
@@ -286,6 +296,7 @@ impl Analysis {
                 storage: Default::default(),
                 loader,
                 prelude_file: None,
+                all_workspace_targets: Arc::default(),
             },
         }
     }
@@ -306,6 +317,10 @@ impl Analysis {
 
     pub fn set_bazel_prelude_file(&mut self, file_id: FileId) {
         self.db.set_bazel_prelude_file(file_id);
+    }
+
+    pub fn set_all_workspace_targets(&mut self, targets: Vec<String>) {
+        self.db.set_all_workspace_targets(targets);
     }
 }
 

--- a/crates/starpls_ide/src/lib.rs
+++ b/crates/starpls_ide/src/lib.rs
@@ -192,6 +192,10 @@ impl starpls_common::Db for Database {
 
         Ok(Some(resolved_path))
     }
+
+    fn resolve_build_file(&self, file_id: FileId) -> Option<String> {
+        self.loader.resolve_build_file(file_id)
+    }
 }
 
 impl starpls_hir::Db for Database {
@@ -469,6 +473,9 @@ pub trait FileLoader: Send + Sync + 'static {
         dialect: Dialect,
         from: FileId,
     ) -> anyhow::Result<Option<Vec<LoadItemCandidate>>>;
+
+    /// If the specified file is a BUILD file, returns its package.
+    fn resolve_build_file(&self, file_id: FileId) -> Option<String>;
 }
 
 /// [`FileLoader`] that looks up files by path from a hash map.
@@ -518,5 +525,9 @@ impl FileLoader for SimpleFileLoader {
         _from: FileId,
     ) -> anyhow::Result<Option<ResolvedPath>> {
         Ok(None)
+    }
+
+    fn resolve_build_file(&self, _file_id: FileId) -> Option<String> {
+        None
     }
 }

--- a/crates/starpls_ide/src/lib.rs
+++ b/crates/starpls_ide/src/lib.rs
@@ -381,13 +381,23 @@ impl AnalysisSnapshot {
         starpls_hir::Cancelled::catch(|| f(&self.db))
     }
 
-    /// This should only be used as a convenient way to create analysis snapshots
-    /// from test data.
     #[cfg(test)]
     pub fn from_single_file(
         contents: &str,
         dialect: Dialect,
         info: Option<FileInfo>,
+    ) -> (Self, FileId) {
+        Self::from_single_file_with_options(contents, dialect, info, vec![])
+    }
+
+    /// This should only be used as a convenient way to create analysis snapshots
+    /// from test data.
+    #[cfg(test)]
+    pub fn from_single_file_with_options(
+        contents: &str,
+        dialect: Dialect,
+        info: Option<FileInfo>,
+        all_workspace_targets: Vec<String>,
     ) -> (Self, FileId) {
         use starpls_test_util::make_test_builtins;
         use starpls_test_util::FixtureType;
@@ -414,6 +424,7 @@ impl AnalysisSnapshot {
             make_test_builtins(functions, globals, types),
             Builtins::default(),
         );
+        analysis.db.set_all_workspace_targets(all_workspace_targets);
         analysis.apply_change(change);
         (analysis.snapshot(), file_id)
     }

--- a/crates/starpls_ide/src/lib.rs
+++ b/crates/starpls_ide/src/lib.rs
@@ -371,6 +371,7 @@ impl AnalysisSnapshot {
         info: Option<FileInfo>,
     ) -> (Self, FileId) {
         use starpls_test_util::make_test_builtins;
+        use starpls_test_util::FixtureType;
 
         let mut file_set = FxHashMap::default();
         let file_id = FileId(0);
@@ -386,8 +387,8 @@ impl AnalysisSnapshot {
 
         // Add builtins here as needed for tests.
         let functions = vec!["provider", "rule", "struct"];
-        let globals = vec![];
-        let types = vec![];
+        let globals = vec![("attr", "attr")];
+        let types = vec![FixtureType::new("attr", vec![], vec!["int", "string"])];
 
         analysis.db.set_builtin_defs(
             Dialect::Bazel,

--- a/crates/starpls_ide/src/lib.rs
+++ b/crates/starpls_ide/src/lib.rs
@@ -333,7 +333,7 @@ pub struct AnalysisSnapshot {
 }
 
 impl AnalysisSnapshot {
-    pub fn completion(
+    pub fn completions(
         &self,
         pos: FilePosition,
         trigger_character: Option<String>,

--- a/crates/starpls_test_util/src/lib.rs
+++ b/crates/starpls_test_util/src/lib.rs
@@ -72,7 +72,7 @@ impl FixtureType {
 
 pub fn make_test_builtins(
     functions: Vec<impl ToString>,
-    globals: Vec<(String, String)>,
+    globals: Vec<(impl ToString, impl ToString)>,
     types: Vec<FixtureType>,
 ) -> Builtins {
     Builtins {
@@ -98,8 +98,8 @@ pub fn make_test_builtins(
                 ..Default::default()
             })
             .chain(globals.into_iter().map(|(name, ty)| Value {
-                name,
-                r#type: ty,
+                name: name.to_string(),
+                r#type: ty.to_string(),
                 ..Default::default()
             }))
             .collect(),


### PR DESCRIPTION
Adds the `--experimental_enable_label_completions` flag, which provides completions for label-like strings.

TODO:
- [x] Support relative labels
- [x] Refresh labels from `bazel query` on saving a `BUILD.bazel` file
- [x] Tests
