### PR TITLE
Add Go to Definition for unexists labels

### DIFF
--- a/crates/starpls_ide/src/goto_definition.rs
+++ b/crates/starpls_ide/src/goto_definition.rs
@@ -8,6 +8,7 @@ use starpls_syntax::ast::AstNode;
 use starpls_syntax::ast::{self};
 use starpls_syntax::match_ast;
 use starpls_syntax::SyntaxToken;
+use starpls_syntax::TextRange;
 use starpls_syntax::T;
 
 use crate::util::pick_best_token;
@@ -15,6 +16,7 @@ use crate::Database;
 use crate::FilePosition;
 use crate::LocationLink;
 use crate::ResolvedPath;
+use crate::TextSize;
 
 struct GotoDefinitionHandler<'a> {
     sema: Semantics<'a>,
@@ -200,38 +202,42 @@ impl<'a> GotoDefinitionHandler<'a> {
             } => {
                 let build_file = self.sema.db.get_file(build_file_id)?;
                 let parse = self.sema.parse(build_file).syntax(self.sema.db);
-                let call_expr = parse
-                    .children()
-                    .filter_map(ast::CallExpr::cast)
-                    .find(|expr| {
-                        expr.arguments()
-                            .into_iter()
-                            .flat_map(|args| args.arguments())
-                            .any(|arg| match arg {
-                                ast::Argument::Keyword(arg) => {
-                                    arg.name()
-                                        .and_then(|name| name.name())
-                                        .map(|name| name.text() == "name")
-                                        .unwrap_or_default()
-                                        && arg
-                                            .expr()
-                                            .and_then(|expr| match expr {
-                                                ast::Expression::Literal(expr) => Some(expr),
-                                                _ => None,
-                                            })
-                                            .and_then(|expr| match expr.kind() {
-                                                ast::LiteralKind::String(s) => {
-                                                    s.value().map(|value| *value == target)
-                                                }
-                                                _ => None,
-                                            })
+                let optional_call_expr =
+                    parse
+                        .children()
+                        .filter_map(ast::CallExpr::cast)
+                        .find(|expr| {
+                            expr.arguments()
+                                .into_iter()
+                                .flat_map(|args| args.arguments())
+                                .any(|arg| match arg {
+                                    ast::Argument::Keyword(arg) => {
+                                        arg.name()
+                                            .and_then(|name| name.name())
+                                            .map(|name| name.text() == "name")
                                             .unwrap_or_default()
-                                }
-                                _ => false,
-                            })
-                    })?;
+                                            && arg
+                                                .expr()
+                                                .and_then(|expr| match expr {
+                                                    ast::Expression::Literal(expr) => Some(expr),
+                                                    _ => None,
+                                                })
+                                                .and_then(|expr| match expr.kind() {
+                                                    ast::LiteralKind::String(s) => {
+                                                        s.value().map(|value| *value == target)
+                                                    }
+                                                    _ => None,
+                                                })
+                                                .unwrap_or_default()
+                                    }
+                                    _ => false,
+                                })
+                        });
+                let range = match optional_call_expr {
+                    Some(call_expr) => call_expr.syntax().text_range(),
+                    None => TextRange::new(TextSize::new(0), TextSize::new(0)),
+                };
 
-                let range = call_expr.syntax().text_range();
                 Some(vec![LocationLink::Local {
                     origin_selection_range: Some(self.token.text_range()),
                     target_range: range,


### PR DESCRIPTION
This PR implements a new feature that enables the "go to definition" functionality for labels that are not defined within a package.
This enhancement is particularly useful when navigating definitions for labels like `visibility = ["//path/to/package:__subpackages__"]`.