### PR TITLE
feat: add branch to git_override

### DIFF
--- a/crates/starpls_bazel/data/module-bazel.builtins.json
+++ b/crates/starpls_bazel/data/module-bazel.builtins.json
@@ -202,6 +202,15 @@
             "is_mandatory": false,
             "is_star_arg": false,
             "is_star_star_arg": false
+          },
+          {
+            "name": "branch",
+            "type": "string",
+            "doc": "The branch to checkout. If not specified, the default branch is used.",
+            "default_value": "''",
+            "is_mandatory": false,
+            "is_star_arg": false,
+            "is_star_star_arg": false
           }
         ],
         "return_type": "None"


### PR DESCRIPTION
I got an error when using the 'branch' parameter with git_override: starpls: Unexpected keyword argument "branch". It appears this parameter is not implemented in your language server.

https://bazel.build/rules/lib/repo/git#git_repository-branch