### PR TITLE
Fix new nightly type mismatch

### DIFF
--- a/crates/starpls/src/event_loop.rs
+++ b/crates/starpls/src/event_loop.rs
@@ -345,7 +345,7 @@ impl Server {
     }
 
     fn respond(&mut self, resp: lsp_server::Response) {
-        if self.req_queue.incoming.complete(resp.id.clone()).is_some() {
+        if self.req_queue.incoming.complete(&resp.id.clone()).is_some() {
             self.connection.sender.send(resp.into()).unwrap();
         }
     }


### PR DESCRIPTION
```
error[E0308]: mismatched types
   --> crates/starpls/src/event_loop.rs:348:45
    |
348 |         if self.req_queue.incoming.complete(resp.id.clone()).is_some() {
    |                                    -------- ^^^^^^^^^^^^^^^ expected `&RequestId`, found `RequestId`
    |                                    |
    |                                    arguments to this method are incorrect
    |
note: method defined here
   --> ~/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/lsp-server-0.7.8/src/req_queue.rs:47:12
    |
47  |     pub fn complete(&mut self, id: &RequestId) -> Option<I> {
    |            ^^^^^^^^
help: consider borrowing here
    |
348 |         if self.req_queue.incoming.complete(&resp.id.clone()).is_some() {
    |                                             +
```
