### PR TITLE
fix: support fail function signature with deprecated params

### DIFF
--- a/crates/starpls/src/commands/check.rs
+++ b/crates/starpls/src/commands/check.rs
@@ -125,6 +125,7 @@ fn diagnostic_to_message<'a>(
     let start: usize = diagnostic.range.range.start().into();
     let end: usize = diagnostic.range.range.end().into();
     let level = match diagnostic.severity {
+        Severity::Info => Level::Info,
         Severity::Warning => Level::Warning,
         Severity::Error => Level::Error,
     };
@@ -247,10 +248,12 @@ impl Checker {
         metadata: &FileMetadata,
         num_errors: &mut usize,
         num_warnings: &mut usize,
+        num_infos: &mut usize,
     ) -> anyhow::Result<()> {
         let renderer = Renderer::styled();
         for diagnostic in snapshot.diagnostics(file_id)? {
             match diagnostic.severity {
+                Severity::Info => *num_infos += 1,
                 Severity::Warning => *num_warnings += 1,
                 Severity::Error => *num_errors += 1,
             }
@@ -266,6 +269,7 @@ impl Checker {
         let snapshot = self.analysis.snapshot();
         let mut num_errors = 0;
         let mut num_warnings = 0;
+        let mut num_infos = 0;
 
         let mut ignored_files = self.ignored_files.iter().collect::<Vec<_>>();
         ignored_files.sort();
@@ -290,6 +294,7 @@ impl Checker {
                 metadata,
                 &mut num_errors,
                 &mut num_warnings,
+                &mut num_infos,
             )?;
         }
 

--- a/crates/starpls/src/convert.rs
+++ b/crates/starpls/src/convert.rs
@@ -91,6 +91,7 @@ fn lsp_severity_from_native(severity: Severity) -> lsp_types::DiagnosticSeverity
     match severity {
         Severity::Error => lsp_types::DiagnosticSeverity::ERROR,
         Severity::Warning => lsp_types::DiagnosticSeverity::WARNING,
+        Severity::Info => lsp_types::DiagnosticSeverity::INFORMATION,
     }
 }
 

--- a/crates/starpls_common/src/diagnostics.rs
+++ b/crates/starpls_common/src/diagnostics.rs
@@ -20,6 +20,7 @@ pub struct FileRange {
 /// A severity level for diagnostic messages.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Severity {
+    Info,
     Warning,
     Error,
 }

--- a/crates/starpls_hir/src/display.rs
+++ b/crates/starpls_hir/src/display.rs
@@ -212,7 +212,7 @@ impl DisplayWithDb for TyKind {
                                 f.write_str(" = None")?;
                             }
                         }
-                        IntrinsicFunctionParam::Keyword { name, ty } => {
+                        IntrinsicFunctionParam::Keyword { name, ty, .. } => {
                             f.write_str(name.as_str())?;
                             f.write_str(": ")?;
                             ty.substitute(&subst.args).fmt(db, f)?;

--- a/crates/starpls_hir/src/typeck/infer.rs
+++ b/crates/starpls_hir/src/typeck/infer.rs
@@ -810,36 +810,17 @@ impl TyContext<'_> {
                                     {
                                         if *deprecated {
                                             let source_map = source_map(self.db, file);
-                                            let arg_name_node = match source_map
+                                            let arg_name_node = source_map
                                                 .expr_map_back
                                                 .get(&expr)
-                                            {
-                                                Some(arg_value_ptr) => match arg_value_ptr
-                                                    .syntax_node_ptr()
-                                                    .try_to_node(
+                                                .and_then(|arg_value_ptr| {
+                                                    arg_value_ptr.syntax_node_ptr().try_to_node(
                                                         &parse(self.db, file).syntax(self.db),
-                                                    ) {
-                                                    Some(arg_value_node) => {
-                                                        match arg_value_node.parent() {
-                                                            Some(keyword_arg) => {
-                                                                match ast::KeywordArgument::cast(
-                                                                    keyword_arg,
-                                                                ) {
-                                                                    Some(keyword_arg) => {
-                                                                        keyword_arg.name()
-                                                                    }
-                                                                    None => None,
-                                                                }
-                                                            }
-
-                                                            None => None,
-                                                        }
-                                                    }
-                                                    None => None,
-                                                },
-
-                                                None => None,
-                                            };
+                                                    )
+                                                })
+                                                .and_then(|arg_value_node| arg_value_node.parent())
+                                                .and_then(ast::KeywordArgument::cast)
+                                                .and_then(|keyword_arg| keyword_arg.name());
                                             if let Some(arg_name_node) = arg_name_node {
                                                 self.add_diagnostic_for_range(
                                                     file,

--- a/crates/starpls_hir/src/typeck/infer.rs
+++ b/crates/starpls_hir/src/typeck/infer.rs
@@ -802,6 +802,58 @@ impl TyContext<'_> {
                                     if !assign_tys(db, ty, &param_ty) {
                                         self.add_expr_diagnostic_error(file, expr, format!("Argument of type \"{}\" cannot be assigned to parameter of type \"{}\"", ty.display(self.db).alt(), param_ty.display(self.db).alt()));
                                     }
+                                    if let IntrinsicFunctionParam::Keyword {
+                                        name,
+                                        deprecated,
+                                        ..
+                                    } = param
+                                    {
+                                        if *deprecated {
+                                            let source_map = source_map(self.db, file);
+                                            let arg_name_node = match source_map
+                                                .expr_map_back
+                                                .get(&expr)
+                                            {
+                                                Some(arg_value_ptr) => match arg_value_ptr
+                                                    .syntax_node_ptr()
+                                                    .try_to_node(
+                                                        &parse(self.db, file).syntax(self.db),
+                                                    ) {
+                                                    Some(arg_value_node) => {
+                                                        match arg_value_node.parent() {
+                                                            Some(keyword_arg) => {
+                                                                match ast::KeywordArgument::cast(
+                                                                    keyword_arg,
+                                                                ) {
+                                                                    Some(keyword_arg) => {
+                                                                        keyword_arg.name()
+                                                                    }
+                                                                    None => None,
+                                                                }
+                                                            }
+
+                                                            None => None,
+                                                        }
+                                                    }
+                                                    None => None,
+                                                },
+
+                                                None => None,
+                                            };
+                                            if let Some(arg_name_node) = arg_name_node {
+                                                self.add_diagnostic_for_range(
+                                                    file,
+                                                    Severity::Info,
+                                                    arg_name_node.syntax().text_range(),
+                                                    Some(vec![DiagnosticTag::Deprecated]),
+                                                    format!(
+                                                        "Argument \"{}\" is deprecated",
+                                                        name.as_str()
+                                                    ),
+                                                );
+                                            }
+                                        }
+                                    }
                                 }
                                 _ => {}
                             };

--- a/crates/starpls_hir/src/typeck/intrinsics.rs
+++ b/crates/starpls_hir/src/typeck/intrinsics.rs
@@ -177,9 +177,18 @@ impl IntrinsicFunction {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub(crate) enum IntrinsicFunctionParam {
-    Positional { ty: Ty, optional: bool },
-    Keyword { name: Name, ty: Ty },
-    ArgsList { ty: Ty },
+    Positional {
+        ty: Ty,
+        optional: bool,
+    },
+    Keyword {
+        name: Name,
+        ty: Ty,
+        deprecated: bool,
+    },
+    ArgsList {
+        ty: Ty,
+    },
     KwargsDict,
 }
 
@@ -513,6 +522,7 @@ max("two", "three", "four", key=len)            # "three", the longest
             Keyword {
                 name: Name::new_inline("key"),
                 ty: Any.intern(),
+                deprecated: false,
             },
         ],
         Any,
@@ -538,6 +548,7 @@ min("two", "three", "four", key=len)            # "two", the shortest
             Keyword {
                 name: Name::new_inline("key"),
                 ty: Any.intern(),
+                deprecated: false,
             },
         ],
         Any,
@@ -565,6 +576,7 @@ determined by the host application.
             Keyword {
                 name: Name::new_inline("str"),
                 ty: Ty::string(),
+                deprecated: false,
             },
         ],
         None,
@@ -689,10 +701,12 @@ sorted(["two", "three", "four"], key=len, reverse=True)    # ["three", "four", "
             Keyword {
                 name: Name::new_inline("reverse"),
                 ty: non_literal_bool().intern(),
+                deprecated: false,
             },
             Keyword {
                 name: Name::new_inline("key"),
                 ty: Any.intern(),
+                deprecated: false,
             },
         ],
         List(Any.intern()),

--- a/crates/starpls_hir/src/typeck/intrinsics.rs
+++ b/crates/starpls_hir/src/typeck/intrinsics.rs
@@ -364,7 +364,24 @@ fail("oops")			# "fail: oops"
 fail("oops", 1, False)		# "fail: oops 1 False"
 ```
 "#,
-        vec![ArgsList { ty: Any.intern() }],
+        vec![
+            Keyword {
+                name: Name::new_inline("msg"),
+                ty: Ty::string(),
+                deprecated: true,
+            },
+            Keyword {
+                name: Name::new_inline("attr"),
+                ty: Ty::string(),
+                deprecated: true,
+            },
+            Keyword {
+                name: Name::new_inline("sep"),
+                ty: TyKind::String(Some(InternedString::new(db, " ".to_string().into_boxed_str()))).intern(),
+                deprecated: false,
+            },
+            ArgsList { ty: Any.intern() },
+        ],
         Never,
     );
     add_function(

--- a/crates/starpls_hir/src/typeck/intrinsics.rs
+++ b/crates/starpls_hir/src/typeck/intrinsics.rs
@@ -386,7 +386,11 @@ fail("oops", 1, False)		# "fail: oops 1 False"
             },
             Keyword {
                 name: Name::new_inline("sep"),
-                ty: TyKind::String(Some(InternedString::new(db, " ".to_string().into_boxed_str()))).intern(),
+                ty: TyKind::String(Some(InternedString::new(
+                    db,
+                    " ".to_string().into_boxed_str(),
+                )))
+                .intern(),
                 deprecated: false,
             },
             ArgsList { ty: Any.intern() },

--- a/crates/starpls_hir/src/typeck/tests.rs
+++ b/crates/starpls_hir/src/typeck/tests.rs
@@ -1958,6 +1958,24 @@ d["foo"] = 1
 }
 
 #[test]
+fn test_fail_deprecated_args() {
+    check_infer(
+        r#"
+fail(msg = "foo", attr = "bar")
+"#,
+        expect![[r#"
+            1..5 "fail": def fail(msg: string = None, attr: string = None, sep: Literal[" "] = None, *args: Any) -> Never
+            12..17 "\"foo\"": Literal["foo"]
+            26..31 "\"bar\"": Literal["bar"]
+            1..32 "fail(msg = \"foo\", attr = \"bar\")": Never
+
+            6..9 Argument "msg" is deprecated
+            19..23 Argument "attr" is deprecated
+        "#]],
+    );
+}
+
+#[test]
 fn test_if_else_stmts() {
     check_infer_with_code_flow_analysis(
         r#"


### PR DESCRIPTION
### Problem

I was getting a type error with some old code using the `attr` keyword argument of the `fail` method. According to the [function signature](https://bazel.build/rules/lib/globals/all.html#fail), the `attr` does exist, but it's deprecated.

### Solution

Add the missing keyword arguments to the `fail` and mark them as deprecated. Additionally we add an info diagnostic marked as deprecated to these usages of this parameter.

would also appreciate any feedback on the pull request 🙏 i did see that there was a comment on not applying DRY for function params so would like to help if appropriate here