### PR TITLE
chore: upgrade to rust 1.87.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,7 +16,7 @@ use_repo(zig_toolchains, "zig_sdk")
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 rust.toolchain(
     edition = "2021",
-    versions = ["nightly/2023-12-06"],
+    versions = ["1.87.0"],
     extra_target_triples = ["aarch64-unknown-linux-gnu"],
 )
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,5 +1,5 @@
 {
-  "lockFileVersion": 16,
+  "lockFileVersion": 18,
   "registryFileHashes": {
     "https://bcr.bazel.build/bazel_registry.json": "8a28e4aff06ee60aed2a8c281907fb8bcbf3b753c91fb5a5c57da3215d5b3497",
     "https://bcr.bazel.build/modules/abseil-cpp/20210324.2/MODULE.bazel": "7cd0312e064fde87c8d1cd79ba06c876bd23630c83466e9500321be55c96ace2",
@@ -97,7 +97,8 @@
     "https://bcr.bazel.build/modules/rules_cc/0.0.14/MODULE.bazel": "5e343a3aac88b8d7af3b1b6d2093b55c347b8eefc2e7d1442f7a02dc8fea48ac",
     "https://bcr.bazel.build/modules/rules_cc/0.0.15/MODULE.bazel": "6704c35f7b4a72502ee81f61bf88706b54f06b3cbe5558ac17e2e14666cd5dcc",
     "https://bcr.bazel.build/modules/rules_cc/0.0.16/MODULE.bazel": "7661303b8fc1b4d7f532e54e9d6565771fea666fbdf839e0a86affcd02defe87",
-    "https://bcr.bazel.build/modules/rules_cc/0.0.16/source.json": "227e83737046aa4f50015da48e98e0d8ab42fd0ec74d8d653b6cc9f9a357f200",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.17/MODULE.bazel": "2ae1d8f4238ec67d7185d8861cb0a2cdf4bc608697c331b95bf990e69b62e64a",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.17/source.json": "4db99b3f55c90ab28d14552aa0632533e3e8e5e9aea0f5c24ac0014282c2a7c5",
     "https://bcr.bazel.build/modules/rules_cc/0.0.2/MODULE.bazel": "6915987c90970493ab97393024c156ea8fb9f3bea953b2f3ec05c34f19b5695c",
     "https://bcr.bazel.build/modules/rules_cc/0.0.6/MODULE.bazel": "abf360251023dfe3efcef65ab9d56beefa8394d4176dd29529750e1c57eaa33f",
     "https://bcr.bazel.build/modules/rules_cc/0.0.8/MODULE.bazel": "964c85c82cfeb6f3855e6a07054fdb159aced38e99a5eecf7bce9d53990afa3e",
@@ -119,8 +120,8 @@
     "https://bcr.bazel.build/modules/rules_java/7.2.0/MODULE.bazel": "06c0334c9be61e6cef2c8c84a7800cef502063269a5af25ceb100b192453d4ab",
     "https://bcr.bazel.build/modules/rules_java/7.3.2/MODULE.bazel": "50dece891cfdf1741ea230d001aa9c14398062f2b7c066470accace78e412bc2",
     "https://bcr.bazel.build/modules/rules_java/7.6.1/MODULE.bazel": "2f14b7e8a1aa2f67ae92bc69d1ec0fa8d9f827c4e17ff5e5f02e91caa3b2d0fe",
-    "https://bcr.bazel.build/modules/rules_java/8.6.1/MODULE.bazel": "f4808e2ab5b0197f094cabce9f4b006a27766beb6a9975931da07099560ca9c2",
-    "https://bcr.bazel.build/modules/rules_java/8.6.1/source.json": "f18d9ad3c4c54945bf422ad584fa6c5ca5b3116ff55a5b1bc77e5c1210be5960",
+    "https://bcr.bazel.build/modules/rules_java/8.11.0/MODULE.bazel": "c3d280bc5ff1038dcb3bacb95d3f6b83da8dd27bba57820ec89ea4085da767ad",
+    "https://bcr.bazel.build/modules/rules_java/8.11.0/source.json": "302b52a39259a85aa06ca3addb9787864ca3e03b432a5f964ea68244397e7544",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
@@ -181,7 +182,7 @@
   "moduleExtensions": {
     "@@apple_support+//crosstool:setup.bzl%apple_cc_configure_extension": {
       "general": {
-        "bzlTransitiveDigest": "toI2CJrfSjyrO+VKLMSvyJeQBo38LpM/Y452BrL9PRE=",
+        "bzlTransitiveDigest": "j2n5eTfqiyvFwBkzLiuz86tkP+QtdOx/yDIX7evxgH8=",
         "usagesDigest": "2g11pC3meeC9i6QJ70IQ9kqRygrhz9bj/s9la710uQE=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -791,28 +792,6 @@
         "recordedRepoMappingEntries": []
       }
     },
-    "@@rules_java+//java:rules_java_deps.bzl%compatibility_proxy": {
-      "general": {
-        "bzlTransitiveDigest": "84xJEZ1jnXXwo8BXMprvBm++rRt4jsTu9liBxz0ivps=",
-        "usagesDigest": "jTQDdLDxsS43zuRmg1faAjIEPWdLAbDAowI1pInQSoo=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "compatibility_proxy": {
-            "repoRuleId": "@@rules_java+//java:rules_java_deps.bzl%_compatibility_proxy_repo_rule",
-            "attributes": {}
-          }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "rules_java+",
-            "bazel_tools",
-            "bazel_tools"
-          ]
-        ]
-      }
-    },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
         "bzlTransitiveDigest": "sFhcgPbDQehmbD1EOXzX4H1q/CD5df8zwG4kp4jbvr8=",
@@ -1000,16 +979,16 @@
     },
     "@@rules_rust+//rust:extensions.bzl%rust": {
       "general": {
-        "bzlTransitiveDigest": "2z4xwPAnNKEYo/ZCs4AbGgtuD1CGN394dNKvZPvvH/8=",
-        "usagesDigest": "JMI9Xl07UO21UOpErVWbqRwMPE3EGquPsGewzN/qgbc=",
+        "bzlTransitiveDigest": "tZknFN58Mn+ltPAhX9xKtwEh/jXADOU0NnAzChh28Do=",
+        "usagesDigest": "w046STE4JyKonZ88P3JKhlXQRgcwpbe4SDC82xDp9hQ=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
         "generatedRepoSpecs": {
-          "rust_analyzer_nightly-2023-12-06_tools": {
+          "rust_analyzer_1.87.0_tools": {
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_analyzer_toolchain_tools_repository",
             "attributes": {
-              "version": "nightly/2023-12-06",
+              "version": "1.87.0",
               "sha256s": {},
               "urls": [
                 "https://static.rust-lang.org/dist/{}.tar.xz"
@@ -1019,23 +998,23 @@
               "auth_patterns": []
             }
           },
-          "rust_analyzer_nightly-2023-12-06": {
+          "rust_analyzer_1.87.0": {
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
             "attributes": {
-              "toolchain": "@rust_analyzer_nightly-2023-12-06_tools//:rust_analyzer_toolchain",
+              "toolchain": "@rust_analyzer_1.87.0_tools//:rust_analyzer_toolchain",
               "toolchain_type": "@rules_rust//rust/rust_analyzer:toolchain_type",
               "exec_compatible_with": [],
               "target_compatible_with": []
             }
           },
-          "rust_darwin_aarch64__aarch64-apple-darwin__nightly_tools": {
+          "rust_darwin_aarch64__aarch64-apple-darwin__stable_tools": {
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
             "attributes": {
               "exec_triple": "aarch64-apple-darwin",
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "aarch64-apple-darwin",
-              "version": "nightly/2023-12-06",
+              "version": "1.87.0",
               "rustfmt_version": "nightly/2024-09-05",
               "edition": "2021",
               "dev_components": false,
@@ -1051,12 +1030,12 @@
               "auth_patterns": []
             }
           },
-          "rust_darwin_aarch64__aarch64-apple-darwin__nightly": {
+          "rust_darwin_aarch64__aarch64-apple-darwin__stable": {
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
             "attributes": {
-              "toolchain": "@rust_darwin_aarch64__aarch64-apple-darwin__nightly_tools//:rust_toolchain",
+              "toolchain": "@rust_darwin_aarch64__aarch64-apple-darwin__stable_tools//:rust_toolchain",
               "target_settings": [
-                "@rules_rust//rust/toolchain/channel:nightly"
+                "@rules_rust//rust/toolchain/channel:stable"
               ],
               "toolchain_type": "@rules_rust//rust:toolchain",
               "exec_compatible_with": [
@@ -1069,14 +1048,14 @@
               ]
             }
           },
-          "rust_darwin_aarch64__aarch64-unknown-linux-gnu__nightly_tools": {
+          "rust_darwin_aarch64__aarch64-unknown-linux-gnu__stable_tools": {
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
             "attributes": {
               "exec_triple": "aarch64-apple-darwin",
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "aarch64-unknown-linux-gnu",
-              "version": "nightly/2023-12-06",
+              "version": "1.87.0",
               "rustfmt_version": "nightly/2024-09-05",
               "edition": "2021",
               "dev_components": false,
@@ -1092,12 +1071,12 @@
               "auth_patterns": []
             }
           },
-          "rust_darwin_aarch64__aarch64-unknown-linux-gnu__nightly": {
+          "rust_darwin_aarch64__aarch64-unknown-linux-gnu__stable": {
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
             "attributes": {
-              "toolchain": "@rust_darwin_aarch64__aarch64-unknown-linux-gnu__nightly_tools//:rust_toolchain",
+              "toolchain": "@rust_darwin_aarch64__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
               "target_settings": [
-                "@rules_rust//rust/toolchain/channel:nightly"
+                "@rules_rust//rust/toolchain/channel:stable"
               ],
               "toolchain_type": "@rules_rust//rust:toolchain",
               "exec_compatible_with": [
@@ -1114,8 +1093,8 @@
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_set_repository",
             "attributes": {
               "toolchains": [
-                "@rust_darwin_aarch64__aarch64-apple-darwin__nightly//:toolchain",
-                "@rust_darwin_aarch64__aarch64-unknown-linux-gnu__nightly//:toolchain"
+                "@rust_darwin_aarch64__aarch64-apple-darwin__stable//:toolchain",
+                "@rust_darwin_aarch64__aarch64-unknown-linux-gnu__stable//:toolchain"
               ]
             }
           },
@@ -1146,14 +1125,14 @@
               "target_compatible_with": []
             }
           },
-          "rust_windows_aarch64__aarch64-pc-windows-msvc__nightly_tools": {
+          "rust_windows_aarch64__aarch64-pc-windows-msvc__stable_tools": {
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
             "attributes": {
               "exec_triple": "aarch64-pc-windows-msvc",
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "aarch64-pc-windows-msvc",
-              "version": "nightly/2023-12-06",
+              "version": "1.87.0",
               "rustfmt_version": "nightly/2024-09-05",
               "edition": "2021",
               "dev_components": false,
@@ -1169,12 +1148,12 @@
               "auth_patterns": []
             }
           },
-          "rust_windows_aarch64__aarch64-pc-windows-msvc__nightly": {
+          "rust_windows_aarch64__aarch64-pc-windows-msvc__stable": {
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
             "attributes": {
-              "toolchain": "@rust_windows_aarch64__aarch64-pc-windows-msvc__nightly_tools//:rust_toolchain",
+              "toolchain": "@rust_windows_aarch64__aarch64-pc-windows-msvc__stable_tools//:rust_toolchain",
               "target_settings": [
-                "@rules_rust//rust/toolchain/channel:nightly"
+                "@rules_rust//rust/toolchain/channel:stable"
               ],
               "toolchain_type": "@rules_rust//rust:toolchain",
               "exec_compatible_with": [
@@ -1187,14 +1166,14 @@
               ]
             }
           },
-          "rust_windows_aarch64__aarch64-unknown-linux-gnu__nightly_tools": {
+          "rust_windows_aarch64__aarch64-unknown-linux-gnu__stable_tools": {
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
             "attributes": {
               "exec_triple": "aarch64-pc-windows-msvc",
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "aarch64-unknown-linux-gnu",
-              "version": "nightly/2023-12-06",
+              "version": "1.87.0",
               "rustfmt_version": "nightly/2024-09-05",
               "edition": "2021",
               "dev_components": false,
@@ -1210,12 +1189,12 @@
               "auth_patterns": []
             }
           },
-          "rust_windows_aarch64__aarch64-unknown-linux-gnu__nightly": {
+          "rust_windows_aarch64__aarch64-unknown-linux-gnu__stable": {
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
             "attributes": {
-              "toolchain": "@rust_windows_aarch64__aarch64-unknown-linux-gnu__nightly_tools//:rust_toolchain",
+              "toolchain": "@rust_windows_aarch64__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
               "target_settings": [
-                "@rules_rust//rust/toolchain/channel:nightly"
+                "@rules_rust//rust/toolchain/channel:stable"
               ],
               "toolchain_type": "@rules_rust//rust:toolchain",
               "exec_compatible_with": [
@@ -1232,8 +1211,8 @@
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_set_repository",
             "attributes": {
               "toolchains": [
-                "@rust_windows_aarch64__aarch64-pc-windows-msvc__nightly//:toolchain",
-                "@rust_windows_aarch64__aarch64-unknown-linux-gnu__nightly//:toolchain"
+                "@rust_windows_aarch64__aarch64-pc-windows-msvc__stable//:toolchain",
+                "@rust_windows_aarch64__aarch64-unknown-linux-gnu__stable//:toolchain"
               ]
             }
           },
@@ -1264,14 +1243,14 @@
               "target_compatible_with": []
             }
           },
-          "rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly_tools": {
+          "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable_tools": {
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
             "attributes": {
               "exec_triple": "aarch64-unknown-linux-gnu",
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "aarch64-unknown-linux-gnu",
-              "version": "nightly/2023-12-06",
+              "version": "1.87.0",
               "rustfmt_version": "nightly/2024-09-05",
               "edition": "2021",
               "dev_components": false,
@@ -1287,12 +1266,12 @@
               "auth_patterns": []
             }
           },
-          "rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly": {
+          "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable": {
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
             "attributes": {
-              "toolchain": "@rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly_tools//:rust_toolchain",
+              "toolchain": "@rust_linux_aarch64__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
               "target_settings": [
-                "@rules_rust//rust/toolchain/channel:nightly"
+                "@rules_rust//rust/toolchain/channel:stable"
               ],
               "toolchain_type": "@rules_rust//rust:toolchain",
               "exec_compatible_with": [
@@ -1309,7 +1288,7 @@
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_set_repository",
             "attributes": {
               "toolchains": [
-                "@rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly//:toolchain"
+                "@rust_linux_aarch64__aarch64-unknown-linux-gnu__stable//:toolchain"
               ]
             }
           },
@@ -1340,14 +1319,14 @@
               "target_compatible_with": []
             }
           },
-          "rust_linux_s390x__s390x-unknown-linux-gnu__nightly_tools": {
+          "rust_linux_s390x__s390x-unknown-linux-gnu__stable_tools": {
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
             "attributes": {
               "exec_triple": "s390x-unknown-linux-gnu",
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "s390x-unknown-linux-gnu",
-              "version": "nightly/2023-12-06",
+              "version": "1.87.0",
               "rustfmt_version": "nightly/2024-09-05",
               "edition": "2021",
               "dev_components": false,
@@ -1363,12 +1342,12 @@
               "auth_patterns": []
             }
           },
-          "rust_linux_s390x__s390x-unknown-linux-gnu__nightly": {
+          "rust_linux_s390x__s390x-unknown-linux-gnu__stable": {
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
             "attributes": {
-              "toolchain": "@rust_linux_s390x__s390x-unknown-linux-gnu__nightly_tools//:rust_toolchain",
+              "toolchain": "@rust_linux_s390x__s390x-unknown-linux-gnu__stable_tools//:rust_toolchain",
               "target_settings": [
-                "@rules_rust//rust/toolchain/channel:nightly"
+                "@rules_rust//rust/toolchain/channel:stable"
               ],
               "toolchain_type": "@rules_rust//rust:toolchain",
               "exec_compatible_with": [
@@ -1381,14 +1360,14 @@
               ]
             }
           },
-          "rust_linux_s390x__aarch64-unknown-linux-gnu__nightly_tools": {
+          "rust_linux_s390x__aarch64-unknown-linux-gnu__stable_tools": {
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
             "attributes": {
               "exec_triple": "s390x-unknown-linux-gnu",
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "aarch64-unknown-linux-gnu",
-              "version": "nightly/2023-12-06",
+              "version": "1.87.0",
               "rustfmt_version": "nightly/2024-09-05",
               "edition": "2021",
               "dev_components": false,
@@ -1404,12 +1383,12 @@
               "auth_patterns": []
             }
           },
-          "rust_linux_s390x__aarch64-unknown-linux-gnu__nightly": {
+          "rust_linux_s390x__aarch64-unknown-linux-gnu__stable": {
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
             "attributes": {
-              "toolchain": "@rust_linux_s390x__aarch64-unknown-linux-gnu__nightly_tools//:rust_toolchain",
+              "toolchain": "@rust_linux_s390x__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
               "target_settings": [
-                "@rules_rust//rust/toolchain/channel:nightly"
+                "@rules_rust//rust/toolchain/channel:stable"
               ],
               "toolchain_type": "@rules_rust//rust:toolchain",
               "exec_compatible_with": [
@@ -1426,8 +1405,8 @@
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_set_repository",
             "attributes": {
               "toolchains": [
-                "@rust_linux_s390x__s390x-unknown-linux-gnu__nightly//:toolchain",
-                "@rust_linux_s390x__aarch64-unknown-linux-gnu__nightly//:toolchain"
+                "@rust_linux_s390x__s390x-unknown-linux-gnu__stable//:toolchain",
+                "@rust_linux_s390x__aarch64-unknown-linux-gnu__stable//:toolchain"
               ]
             }
           },
@@ -1458,14 +1437,14 @@
               "target_compatible_with": []
             }
           },
-          "rust_darwin_x86_64__x86_64-apple-darwin__nightly_tools": {
+          "rust_darwin_x86_64__x86_64-apple-darwin__stable_tools": {
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
             "attributes": {
               "exec_triple": "x86_64-apple-darwin",
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "x86_64-apple-darwin",
-              "version": "nightly/2023-12-06",
+              "version": "1.87.0",
               "rustfmt_version": "nightly/2024-09-05",
               "edition": "2021",
               "dev_components": false,
@@ -1481,12 +1460,12 @@
               "auth_patterns": []
             }
           },
-          "rust_darwin_x86_64__x86_64-apple-darwin__nightly": {
+          "rust_darwin_x86_64__x86_64-apple-darwin__stable": {
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
             "attributes": {
-              "toolchain": "@rust_darwin_x86_64__x86_64-apple-darwin__nightly_tools//:rust_toolchain",
+              "toolchain": "@rust_darwin_x86_64__x86_64-apple-darwin__stable_tools//:rust_toolchain",
               "target_settings": [
-                "@rules_rust//rust/toolchain/channel:nightly"
+                "@rules_rust//rust/toolchain/channel:stable"
               ],
               "toolchain_type": "@rules_rust//rust:toolchain",
               "exec_compatible_with": [
@@ -1499,14 +1478,14 @@
               ]
             }
           },
-          "rust_darwin_x86_64__aarch64-unknown-linux-gnu__nightly_tools": {
+          "rust_darwin_x86_64__aarch64-unknown-linux-gnu__stable_tools": {
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
             "attributes": {
               "exec_triple": "x86_64-apple-darwin",
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "aarch64-unknown-linux-gnu",
-              "version": "nightly/2023-12-06",
+              "version": "1.87.0",
               "rustfmt_version": "nightly/2024-09-05",
               "edition": "2021",
               "dev_components": false,
@@ -1522,12 +1501,12 @@
               "auth_patterns": []
             }
           },
-          "rust_darwin_x86_64__aarch64-unknown-linux-gnu__nightly": {
+          "rust_darwin_x86_64__aarch64-unknown-linux-gnu__stable": {
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
             "attributes": {
-              "toolchain": "@rust_darwin_x86_64__aarch64-unknown-linux-gnu__nightly_tools//:rust_toolchain",
+              "toolchain": "@rust_darwin_x86_64__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
               "target_settings": [
-                "@rules_rust//rust/toolchain/channel:nightly"
+                "@rules_rust//rust/toolchain/channel:stable"
               ],
               "toolchain_type": "@rules_rust//rust:toolchain",
               "exec_compatible_with": [
@@ -1544,8 +1523,8 @@
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_set_repository",
             "attributes": {
               "toolchains": [
-                "@rust_darwin_x86_64__x86_64-apple-darwin__nightly//:toolchain",
-                "@rust_darwin_x86_64__aarch64-unknown-linux-gnu__nightly//:toolchain"
+                "@rust_darwin_x86_64__x86_64-apple-darwin__stable//:toolchain",
+                "@rust_darwin_x86_64__aarch64-unknown-linux-gnu__stable//:toolchain"
               ]
             }
           },
@@ -1576,14 +1555,14 @@
               "target_compatible_with": []
             }
           },
-          "rust_windows_x86_64__x86_64-pc-windows-msvc__nightly_tools": {
+          "rust_windows_x86_64__x86_64-pc-windows-msvc__stable_tools": {
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
             "attributes": {
               "exec_triple": "x86_64-pc-windows-msvc",
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "x86_64-pc-windows-msvc",
-              "version": "nightly/2023-12-06",
+              "version": "1.87.0",
               "rustfmt_version": "nightly/2024-09-05",
               "edition": "2021",
               "dev_components": false,
@@ -1599,12 +1578,12 @@
               "auth_patterns": []
             }
           },
-          "rust_windows_x86_64__x86_64-pc-windows-msvc__nightly": {
+          "rust_windows_x86_64__x86_64-pc-windows-msvc__stable": {
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
             "attributes": {
-              "toolchain": "@rust_windows_x86_64__x86_64-pc-windows-msvc__nightly_tools//:rust_toolchain",
+              "toolchain": "@rust_windows_x86_64__x86_64-pc-windows-msvc__stable_tools//:rust_toolchain",
               "target_settings": [
-                "@rules_rust//rust/toolchain/channel:nightly"
+                "@rules_rust//rust/toolchain/channel:stable"
               ],
               "toolchain_type": "@rules_rust//rust:toolchain",
               "exec_compatible_with": [
@@ -1617,14 +1596,14 @@
               ]
             }
           },
-          "rust_windows_x86_64__aarch64-unknown-linux-gnu__nightly_tools": {
+          "rust_windows_x86_64__aarch64-unknown-linux-gnu__stable_tools": {
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
             "attributes": {
               "exec_triple": "x86_64-pc-windows-msvc",
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "aarch64-unknown-linux-gnu",
-              "version": "nightly/2023-12-06",
+              "version": "1.87.0",
               "rustfmt_version": "nightly/2024-09-05",
               "edition": "2021",
               "dev_components": false,
@@ -1640,12 +1619,12 @@
               "auth_patterns": []
             }
           },
-          "rust_windows_x86_64__aarch64-unknown-linux-gnu__nightly": {
+          "rust_windows_x86_64__aarch64-unknown-linux-gnu__stable": {
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
             "attributes": {
-              "toolchain": "@rust_windows_x86_64__aarch64-unknown-linux-gnu__nightly_tools//:rust_toolchain",
+              "toolchain": "@rust_windows_x86_64__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
               "target_settings": [
-                "@rules_rust//rust/toolchain/channel:nightly"
+                "@rules_rust//rust/toolchain/channel:stable"
               ],
               "toolchain_type": "@rules_rust//rust:toolchain",
               "exec_compatible_with": [
@@ -1662,8 +1641,8 @@
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_set_repository",
             "attributes": {
               "toolchains": [
-                "@rust_windows_x86_64__x86_64-pc-windows-msvc__nightly//:toolchain",
-                "@rust_windows_x86_64__aarch64-unknown-linux-gnu__nightly//:toolchain"
+                "@rust_windows_x86_64__x86_64-pc-windows-msvc__stable//:toolchain",
+                "@rust_windows_x86_64__aarch64-unknown-linux-gnu__stable//:toolchain"
               ]
             }
           },
@@ -1694,14 +1673,14 @@
               "target_compatible_with": []
             }
           },
-          "rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly_tools": {
+          "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable_tools": {
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
             "attributes": {
               "exec_triple": "x86_64-unknown-freebsd",
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "x86_64-unknown-freebsd",
-              "version": "nightly/2023-12-06",
+              "version": "1.87.0",
               "rustfmt_version": "nightly/2024-09-05",
               "edition": "2021",
               "dev_components": false,
@@ -1717,12 +1696,12 @@
               "auth_patterns": []
             }
           },
-          "rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly": {
+          "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable": {
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
             "attributes": {
-              "toolchain": "@rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly_tools//:rust_toolchain",
+              "toolchain": "@rust_freebsd_x86_64__x86_64-unknown-freebsd__stable_tools//:rust_toolchain",
               "target_settings": [
-                "@rules_rust//rust/toolchain/channel:nightly"
+                "@rules_rust//rust/toolchain/channel:stable"
               ],
               "toolchain_type": "@rules_rust//rust:toolchain",
               "exec_compatible_with": [
@@ -1735,14 +1714,14 @@
               ]
             }
           },
-          "rust_freebsd_x86_64__aarch64-unknown-linux-gnu__nightly_tools": {
+          "rust_freebsd_x86_64__aarch64-unknown-linux-gnu__stable_tools": {
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
             "attributes": {
               "exec_triple": "x86_64-unknown-freebsd",
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "aarch64-unknown-linux-gnu",
-              "version": "nightly/2023-12-06",
+              "version": "1.87.0",
               "rustfmt_version": "nightly/2024-09-05",
               "edition": "2021",
               "dev_components": false,
@@ -1758,12 +1737,12 @@
               "auth_patterns": []
             }
           },
-          "rust_freebsd_x86_64__aarch64-unknown-linux-gnu__nightly": {
+          "rust_freebsd_x86_64__aarch64-unknown-linux-gnu__stable": {
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
             "attributes": {
-              "toolchain": "@rust_freebsd_x86_64__aarch64-unknown-linux-gnu__nightly_tools//:rust_toolchain",
+              "toolchain": "@rust_freebsd_x86_64__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
               "target_settings": [
-                "@rules_rust//rust/toolchain/channel:nightly"
+                "@rules_rust//rust/toolchain/channel:stable"
               ],
               "toolchain_type": "@rules_rust//rust:toolchain",
               "exec_compatible_with": [
@@ -1780,8 +1759,8 @@
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_set_repository",
             "attributes": {
               "toolchains": [
-                "@rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly//:toolchain",
-                "@rust_freebsd_x86_64__aarch64-unknown-linux-gnu__nightly//:toolchain"
+                "@rust_freebsd_x86_64__x86_64-unknown-freebsd__stable//:toolchain",
+                "@rust_freebsd_x86_64__aarch64-unknown-linux-gnu__stable//:toolchain"
               ]
             }
           },
@@ -1812,14 +1791,14 @@
               "target_compatible_with": []
             }
           },
-          "rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly_tools": {
+          "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools": {
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
             "attributes": {
               "exec_triple": "x86_64-unknown-linux-gnu",
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "x86_64-unknown-linux-gnu",
-              "version": "nightly/2023-12-06",
+              "version": "1.87.0",
               "rustfmt_version": "nightly/2024-09-05",
               "edition": "2021",
               "dev_components": false,
@@ -1835,12 +1814,12 @@
               "auth_patterns": []
             }
           },
-          "rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly": {
+          "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable": {
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
             "attributes": {
-              "toolchain": "@rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly_tools//:rust_toolchain",
+              "toolchain": "@rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools//:rust_toolchain",
               "target_settings": [
-                "@rules_rust//rust/toolchain/channel:nightly"
+                "@rules_rust//rust/toolchain/channel:stable"
               ],
               "toolchain_type": "@rules_rust//rust:toolchain",
               "exec_compatible_with": [
@@ -1853,14 +1832,14 @@
               ]
             }
           },
-          "rust_linux_x86_64__aarch64-unknown-linux-gnu__nightly_tools": {
+          "rust_linux_x86_64__aarch64-unknown-linux-gnu__stable_tools": {
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
             "attributes": {
               "exec_triple": "x86_64-unknown-linux-gnu",
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "aarch64-unknown-linux-gnu",
-              "version": "nightly/2023-12-06",
+              "version": "1.87.0",
               "rustfmt_version": "nightly/2024-09-05",
               "edition": "2021",
               "dev_components": false,
@@ -1876,12 +1855,12 @@
               "auth_patterns": []
             }
           },
-          "rust_linux_x86_64__aarch64-unknown-linux-gnu__nightly": {
+          "rust_linux_x86_64__aarch64-unknown-linux-gnu__stable": {
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
             "attributes": {
-              "toolchain": "@rust_linux_x86_64__aarch64-unknown-linux-gnu__nightly_tools//:rust_toolchain",
+              "toolchain": "@rust_linux_x86_64__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
               "target_settings": [
-                "@rules_rust//rust/toolchain/channel:nightly"
+                "@rules_rust//rust/toolchain/channel:stable"
               ],
               "toolchain_type": "@rules_rust//rust:toolchain",
               "exec_compatible_with": [
@@ -1898,8 +1877,8 @@
             "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_set_repository",
             "attributes": {
               "toolchains": [
-                "@rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly//:toolchain",
-                "@rust_linux_x86_64__aarch64-unknown-linux-gnu__nightly//:toolchain"
+                "@rust_linux_x86_64__x86_64-unknown-linux-gnu__stable//:toolchain",
+                "@rust_linux_x86_64__aarch64-unknown-linux-gnu__stable//:toolchain"
               ]
             }
           },
@@ -1934,90 +1913,90 @@
             "repoRuleId": "@@rules_rust+//rust/private:repository_utils.bzl%toolchain_repository_hub",
             "attributes": {
               "toolchain_names": [
-                "rust_analyzer_nightly-2023-12-06",
-                "rust_darwin_aarch64__aarch64-apple-darwin__nightly",
-                "rust_darwin_aarch64__aarch64-unknown-linux-gnu__nightly",
+                "rust_analyzer_1.87.0",
+                "rust_darwin_aarch64__aarch64-apple-darwin__stable",
+                "rust_darwin_aarch64__aarch64-unknown-linux-gnu__stable",
                 "rustfmt_nightly-2024-09-05__aarch64-apple-darwin",
-                "rust_windows_aarch64__aarch64-pc-windows-msvc__nightly",
-                "rust_windows_aarch64__aarch64-unknown-linux-gnu__nightly",
+                "rust_windows_aarch64__aarch64-pc-windows-msvc__stable",
+                "rust_windows_aarch64__aarch64-unknown-linux-gnu__stable",
                 "rustfmt_nightly-2024-09-05__aarch64-pc-windows-msvc",
-                "rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly",
+                "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable",
                 "rustfmt_nightly-2024-09-05__aarch64-unknown-linux-gnu",
-                "rust_linux_s390x__s390x-unknown-linux-gnu__nightly",
-                "rust_linux_s390x__aarch64-unknown-linux-gnu__nightly",
+                "rust_linux_s390x__s390x-unknown-linux-gnu__stable",
+                "rust_linux_s390x__aarch64-unknown-linux-gnu__stable",
                 "rustfmt_nightly-2024-09-05__s390x-unknown-linux-gnu",
-                "rust_darwin_x86_64__x86_64-apple-darwin__nightly",
-                "rust_darwin_x86_64__aarch64-unknown-linux-gnu__nightly",
+                "rust_darwin_x86_64__x86_64-apple-darwin__stable",
+                "rust_darwin_x86_64__aarch64-unknown-linux-gnu__stable",
                 "rustfmt_nightly-2024-09-05__x86_64-apple-darwin",
-                "rust_windows_x86_64__x86_64-pc-windows-msvc__nightly",
-                "rust_windows_x86_64__aarch64-unknown-linux-gnu__nightly",
+                "rust_windows_x86_64__x86_64-pc-windows-msvc__stable",
+                "rust_windows_x86_64__aarch64-unknown-linux-gnu__stable",
                 "rustfmt_nightly-2024-09-05__x86_64-pc-windows-msvc",
-                "rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly",
-                "rust_freebsd_x86_64__aarch64-unknown-linux-gnu__nightly",
+                "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable",
+                "rust_freebsd_x86_64__aarch64-unknown-linux-gnu__stable",
                 "rustfmt_nightly-2024-09-05__x86_64-unknown-freebsd",
-                "rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly",
-                "rust_linux_x86_64__aarch64-unknown-linux-gnu__nightly",
+                "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable",
+                "rust_linux_x86_64__aarch64-unknown-linux-gnu__stable",
                 "rustfmt_nightly-2024-09-05__x86_64-unknown-linux-gnu"
               ],
               "toolchain_labels": {
-                "rust_analyzer_nightly-2023-12-06": "@rust_analyzer_nightly-2023-12-06_tools//:rust_analyzer_toolchain",
-                "rust_darwin_aarch64__aarch64-apple-darwin__nightly": "@rust_darwin_aarch64__aarch64-apple-darwin__nightly_tools//:rust_toolchain",
-                "rust_darwin_aarch64__aarch64-unknown-linux-gnu__nightly": "@rust_darwin_aarch64__aarch64-unknown-linux-gnu__nightly_tools//:rust_toolchain",
+                "rust_analyzer_1.87.0": "@rust_analyzer_1.87.0_tools//:rust_analyzer_toolchain",
+                "rust_darwin_aarch64__aarch64-apple-darwin__stable": "@rust_darwin_aarch64__aarch64-apple-darwin__stable_tools//:rust_toolchain",
+                "rust_darwin_aarch64__aarch64-unknown-linux-gnu__stable": "@rust_darwin_aarch64__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
                 "rustfmt_nightly-2024-09-05__aarch64-apple-darwin": "@rustfmt_nightly-2024-09-05__aarch64-apple-darwin_tools//:rustfmt_toolchain",
-                "rust_windows_aarch64__aarch64-pc-windows-msvc__nightly": "@rust_windows_aarch64__aarch64-pc-windows-msvc__nightly_tools//:rust_toolchain",
-                "rust_windows_aarch64__aarch64-unknown-linux-gnu__nightly": "@rust_windows_aarch64__aarch64-unknown-linux-gnu__nightly_tools//:rust_toolchain",
+                "rust_windows_aarch64__aarch64-pc-windows-msvc__stable": "@rust_windows_aarch64__aarch64-pc-windows-msvc__stable_tools//:rust_toolchain",
+                "rust_windows_aarch64__aarch64-unknown-linux-gnu__stable": "@rust_windows_aarch64__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
                 "rustfmt_nightly-2024-09-05__aarch64-pc-windows-msvc": "@rustfmt_nightly-2024-09-05__aarch64-pc-windows-msvc_tools//:rustfmt_toolchain",
-                "rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly": "@rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly_tools//:rust_toolchain",
+                "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable": "@rust_linux_aarch64__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
                 "rustfmt_nightly-2024-09-05__aarch64-unknown-linux-gnu": "@rustfmt_nightly-2024-09-05__aarch64-unknown-linux-gnu_tools//:rustfmt_toolchain",
-                "rust_linux_s390x__s390x-unknown-linux-gnu__nightly": "@rust_linux_s390x__s390x-unknown-linux-gnu__nightly_tools//:rust_toolchain",
-                "rust_linux_s390x__aarch64-unknown-linux-gnu__nightly": "@rust_linux_s390x__aarch64-unknown-linux-gnu__nightly_tools//:rust_toolchain",
+                "rust_linux_s390x__s390x-unknown-linux-gnu__stable": "@rust_linux_s390x__s390x-unknown-linux-gnu__stable_tools//:rust_toolchain",
+                "rust_linux_s390x__aarch64-unknown-linux-gnu__stable": "@rust_linux_s390x__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
                 "rustfmt_nightly-2024-09-05__s390x-unknown-linux-gnu": "@rustfmt_nightly-2024-09-05__s390x-unknown-linux-gnu_tools//:rustfmt_toolchain",
-                "rust_darwin_x86_64__x86_64-apple-darwin__nightly": "@rust_darwin_x86_64__x86_64-apple-darwin__nightly_tools//:rust_toolchain",
-                "rust_darwin_x86_64__aarch64-unknown-linux-gnu__nightly": "@rust_darwin_x86_64__aarch64-unknown-linux-gnu__nightly_tools//:rust_toolchain",
+                "rust_darwin_x86_64__x86_64-apple-darwin__stable": "@rust_darwin_x86_64__x86_64-apple-darwin__stable_tools//:rust_toolchain",
+                "rust_darwin_x86_64__aarch64-unknown-linux-gnu__stable": "@rust_darwin_x86_64__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
                 "rustfmt_nightly-2024-09-05__x86_64-apple-darwin": "@rustfmt_nightly-2024-09-05__x86_64-apple-darwin_tools//:rustfmt_toolchain",
-                "rust_windows_x86_64__x86_64-pc-windows-msvc__nightly": "@rust_windows_x86_64__x86_64-pc-windows-msvc__nightly_tools//:rust_toolchain",
-                "rust_windows_x86_64__aarch64-unknown-linux-gnu__nightly": "@rust_windows_x86_64__aarch64-unknown-linux-gnu__nightly_tools//:rust_toolchain",
+                "rust_windows_x86_64__x86_64-pc-windows-msvc__stable": "@rust_windows_x86_64__x86_64-pc-windows-msvc__stable_tools//:rust_toolchain",
+                "rust_windows_x86_64__aarch64-unknown-linux-gnu__stable": "@rust_windows_x86_64__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
                 "rustfmt_nightly-2024-09-05__x86_64-pc-windows-msvc": "@rustfmt_nightly-2024-09-05__x86_64-pc-windows-msvc_tools//:rustfmt_toolchain",
-                "rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly": "@rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly_tools//:rust_toolchain",
-                "rust_freebsd_x86_64__aarch64-unknown-linux-gnu__nightly": "@rust_freebsd_x86_64__aarch64-unknown-linux-gnu__nightly_tools//:rust_toolchain",
+                "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable": "@rust_freebsd_x86_64__x86_64-unknown-freebsd__stable_tools//:rust_toolchain",
+                "rust_freebsd_x86_64__aarch64-unknown-linux-gnu__stable": "@rust_freebsd_x86_64__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
                 "rustfmt_nightly-2024-09-05__x86_64-unknown-freebsd": "@rustfmt_nightly-2024-09-05__x86_64-unknown-freebsd_tools//:rustfmt_toolchain",
-                "rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly": "@rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly_tools//:rust_toolchain",
-                "rust_linux_x86_64__aarch64-unknown-linux-gnu__nightly": "@rust_linux_x86_64__aarch64-unknown-linux-gnu__nightly_tools//:rust_toolchain",
+                "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable": "@rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools//:rust_toolchain",
+                "rust_linux_x86_64__aarch64-unknown-linux-gnu__stable": "@rust_linux_x86_64__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
                 "rustfmt_nightly-2024-09-05__x86_64-unknown-linux-gnu": "@rustfmt_nightly-2024-09-05__x86_64-unknown-linux-gnu_tools//:rustfmt_toolchain"
               },
               "toolchain_types": {
-                "rust_analyzer_nightly-2023-12-06": "@rules_rust//rust/rust_analyzer:toolchain_type",
-                "rust_darwin_aarch64__aarch64-apple-darwin__nightly": "@rules_rust//rust:toolchain",
-                "rust_darwin_aarch64__aarch64-unknown-linux-gnu__nightly": "@rules_rust//rust:toolchain",
+                "rust_analyzer_1.87.0": "@rules_rust//rust/rust_analyzer:toolchain_type",
+                "rust_darwin_aarch64__aarch64-apple-darwin__stable": "@rules_rust//rust:toolchain",
+                "rust_darwin_aarch64__aarch64-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
                 "rustfmt_nightly-2024-09-05__aarch64-apple-darwin": "@rules_rust//rust/rustfmt:toolchain_type",
-                "rust_windows_aarch64__aarch64-pc-windows-msvc__nightly": "@rules_rust//rust:toolchain",
-                "rust_windows_aarch64__aarch64-unknown-linux-gnu__nightly": "@rules_rust//rust:toolchain",
+                "rust_windows_aarch64__aarch64-pc-windows-msvc__stable": "@rules_rust//rust:toolchain",
+                "rust_windows_aarch64__aarch64-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
                 "rustfmt_nightly-2024-09-05__aarch64-pc-windows-msvc": "@rules_rust//rust/rustfmt:toolchain_type",
-                "rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly": "@rules_rust//rust:toolchain",
+                "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
                 "rustfmt_nightly-2024-09-05__aarch64-unknown-linux-gnu": "@rules_rust//rust/rustfmt:toolchain_type",
-                "rust_linux_s390x__s390x-unknown-linux-gnu__nightly": "@rules_rust//rust:toolchain",
-                "rust_linux_s390x__aarch64-unknown-linux-gnu__nightly": "@rules_rust//rust:toolchain",
+                "rust_linux_s390x__s390x-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
+                "rust_linux_s390x__aarch64-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
                 "rustfmt_nightly-2024-09-05__s390x-unknown-linux-gnu": "@rules_rust//rust/rustfmt:toolchain_type",
-                "rust_darwin_x86_64__x86_64-apple-darwin__nightly": "@rules_rust//rust:toolchain",
-                "rust_darwin_x86_64__aarch64-unknown-linux-gnu__nightly": "@rules_rust//rust:toolchain",
+                "rust_darwin_x86_64__x86_64-apple-darwin__stable": "@rules_rust//rust:toolchain",
+                "rust_darwin_x86_64__aarch64-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
                 "rustfmt_nightly-2024-09-05__x86_64-apple-darwin": "@rules_rust//rust/rustfmt:toolchain_type",
-                "rust_windows_x86_64__x86_64-pc-windows-msvc__nightly": "@rules_rust//rust:toolchain",
-                "rust_windows_x86_64__aarch64-unknown-linux-gnu__nightly": "@rules_rust//rust:toolchain",
+                "rust_windows_x86_64__x86_64-pc-windows-msvc__stable": "@rules_rust//rust:toolchain",
+                "rust_windows_x86_64__aarch64-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
                 "rustfmt_nightly-2024-09-05__x86_64-pc-windows-msvc": "@rules_rust//rust/rustfmt:toolchain_type",
-                "rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly": "@rules_rust//rust:toolchain",
-                "rust_freebsd_x86_64__aarch64-unknown-linux-gnu__nightly": "@rules_rust//rust:toolchain",
+                "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable": "@rules_rust//rust:toolchain",
+                "rust_freebsd_x86_64__aarch64-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
                 "rustfmt_nightly-2024-09-05__x86_64-unknown-freebsd": "@rules_rust//rust/rustfmt:toolchain_type",
-                "rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly": "@rules_rust//rust:toolchain",
-                "rust_linux_x86_64__aarch64-unknown-linux-gnu__nightly": "@rules_rust//rust:toolchain",
+                "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
+                "rust_linux_x86_64__aarch64-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
                 "rustfmt_nightly-2024-09-05__x86_64-unknown-linux-gnu": "@rules_rust//rust/rustfmt:toolchain_type"
               },
               "exec_compatible_with": {
-                "rust_analyzer_nightly-2023-12-06": [],
-                "rust_darwin_aarch64__aarch64-apple-darwin__nightly": [
+                "rust_analyzer_1.87.0": [],
+                "rust_darwin_aarch64__aarch64-apple-darwin__stable": [
                   "@platforms//cpu:aarch64",
                   "@platforms//os:osx"
                 ],
-                "rust_darwin_aarch64__aarch64-unknown-linux-gnu__nightly": [
+                "rust_darwin_aarch64__aarch64-unknown-linux-gnu__stable": [
                   "@platforms//cpu:aarch64",
                   "@platforms//os:osx"
                 ],
@@ -2025,11 +2004,11 @@
                   "@platforms//cpu:aarch64",
                   "@platforms//os:osx"
                 ],
-                "rust_windows_aarch64__aarch64-pc-windows-msvc__nightly": [
+                "rust_windows_aarch64__aarch64-pc-windows-msvc__stable": [
                   "@platforms//cpu:aarch64",
                   "@platforms//os:windows"
                 ],
-                "rust_windows_aarch64__aarch64-unknown-linux-gnu__nightly": [
+                "rust_windows_aarch64__aarch64-unknown-linux-gnu__stable": [
                   "@platforms//cpu:aarch64",
                   "@platforms//os:windows"
                 ],
@@ -2037,7 +2016,7 @@
                   "@platforms//cpu:aarch64",
                   "@platforms//os:windows"
                 ],
-                "rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly": [
+                "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable": [
                   "@platforms//cpu:aarch64",
                   "@platforms//os:linux"
                 ],
@@ -2045,11 +2024,11 @@
                   "@platforms//cpu:aarch64",
                   "@platforms//os:linux"
                 ],
-                "rust_linux_s390x__s390x-unknown-linux-gnu__nightly": [
+                "rust_linux_s390x__s390x-unknown-linux-gnu__stable": [
                   "@platforms//cpu:s390x",
                   "@platforms//os:linux"
                 ],
-                "rust_linux_s390x__aarch64-unknown-linux-gnu__nightly": [
+                "rust_linux_s390x__aarch64-unknown-linux-gnu__stable": [
                   "@platforms//cpu:s390x",
                   "@platforms//os:linux"
                 ],
@@ -2057,11 +2036,11 @@
                   "@platforms//cpu:s390x",
                   "@platforms//os:linux"
                 ],
-                "rust_darwin_x86_64__x86_64-apple-darwin__nightly": [
+                "rust_darwin_x86_64__x86_64-apple-darwin__stable": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:osx"
                 ],
-                "rust_darwin_x86_64__aarch64-unknown-linux-gnu__nightly": [
+                "rust_darwin_x86_64__aarch64-unknown-linux-gnu__stable": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:osx"
                 ],
@@ -2069,11 +2048,11 @@
                   "@platforms//cpu:x86_64",
                   "@platforms//os:osx"
                 ],
-                "rust_windows_x86_64__x86_64-pc-windows-msvc__nightly": [
+                "rust_windows_x86_64__x86_64-pc-windows-msvc__stable": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:windows"
                 ],
-                "rust_windows_x86_64__aarch64-unknown-linux-gnu__nightly": [
+                "rust_windows_x86_64__aarch64-unknown-linux-gnu__stable": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:windows"
                 ],
@@ -2081,11 +2060,11 @@
                   "@platforms//cpu:x86_64",
                   "@platforms//os:windows"
                 ],
-                "rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly": [
+                "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:freebsd"
                 ],
-                "rust_freebsd_x86_64__aarch64-unknown-linux-gnu__nightly": [
+                "rust_freebsd_x86_64__aarch64-unknown-linux-gnu__stable": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:freebsd"
                 ],
@@ -2093,11 +2072,11 @@
                   "@platforms//cpu:x86_64",
                   "@platforms//os:freebsd"
                 ],
-                "rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly": [
+                "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:linux"
                 ],
-                "rust_linux_x86_64__aarch64-unknown-linux-gnu__nightly": [
+                "rust_linux_x86_64__aarch64-unknown-linux-gnu__stable": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:linux"
                 ],
@@ -2107,71 +2086,71 @@
                 ]
               },
               "target_compatible_with": {
-                "rust_analyzer_nightly-2023-12-06": [],
-                "rust_darwin_aarch64__aarch64-apple-darwin__nightly": [
+                "rust_analyzer_1.87.0": [],
+                "rust_darwin_aarch64__aarch64-apple-darwin__stable": [
                   "@platforms//cpu:aarch64",
                   "@platforms//os:osx"
                 ],
-                "rust_darwin_aarch64__aarch64-unknown-linux-gnu__nightly": [
+                "rust_darwin_aarch64__aarch64-unknown-linux-gnu__stable": [
                   "@platforms//cpu:aarch64",
                   "@platforms//os:linux"
                 ],
                 "rustfmt_nightly-2024-09-05__aarch64-apple-darwin": [],
-                "rust_windows_aarch64__aarch64-pc-windows-msvc__nightly": [
+                "rust_windows_aarch64__aarch64-pc-windows-msvc__stable": [
                   "@platforms//cpu:aarch64",
                   "@platforms//os:windows"
                 ],
-                "rust_windows_aarch64__aarch64-unknown-linux-gnu__nightly": [
+                "rust_windows_aarch64__aarch64-unknown-linux-gnu__stable": [
                   "@platforms//cpu:aarch64",
                   "@platforms//os:linux"
                 ],
                 "rustfmt_nightly-2024-09-05__aarch64-pc-windows-msvc": [],
-                "rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly": [
+                "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable": [
                   "@platforms//cpu:aarch64",
                   "@platforms//os:linux"
                 ],
                 "rustfmt_nightly-2024-09-05__aarch64-unknown-linux-gnu": [],
-                "rust_linux_s390x__s390x-unknown-linux-gnu__nightly": [
+                "rust_linux_s390x__s390x-unknown-linux-gnu__stable": [
                   "@platforms//cpu:s390x",
                   "@platforms//os:linux"
                 ],
-                "rust_linux_s390x__aarch64-unknown-linux-gnu__nightly": [
+                "rust_linux_s390x__aarch64-unknown-linux-gnu__stable": [
                   "@platforms//cpu:aarch64",
                   "@platforms//os:linux"
                 ],
                 "rustfmt_nightly-2024-09-05__s390x-unknown-linux-gnu": [],
-                "rust_darwin_x86_64__x86_64-apple-darwin__nightly": [
+                "rust_darwin_x86_64__x86_64-apple-darwin__stable": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:osx"
                 ],
-                "rust_darwin_x86_64__aarch64-unknown-linux-gnu__nightly": [
+                "rust_darwin_x86_64__aarch64-unknown-linux-gnu__stable": [
                   "@platforms//cpu:aarch64",
                   "@platforms//os:linux"
                 ],
                 "rustfmt_nightly-2024-09-05__x86_64-apple-darwin": [],
-                "rust_windows_x86_64__x86_64-pc-windows-msvc__nightly": [
+                "rust_windows_x86_64__x86_64-pc-windows-msvc__stable": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:windows"
                 ],
-                "rust_windows_x86_64__aarch64-unknown-linux-gnu__nightly": [
+                "rust_windows_x86_64__aarch64-unknown-linux-gnu__stable": [
                   "@platforms//cpu:aarch64",
                   "@platforms//os:linux"
                 ],
                 "rustfmt_nightly-2024-09-05__x86_64-pc-windows-msvc": [],
-                "rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly": [
+                "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:freebsd"
                 ],
-                "rust_freebsd_x86_64__aarch64-unknown-linux-gnu__nightly": [
+                "rust_freebsd_x86_64__aarch64-unknown-linux-gnu__stable": [
                   "@platforms//cpu:aarch64",
                   "@platforms//os:linux"
                 ],
                 "rustfmt_nightly-2024-09-05__x86_64-unknown-freebsd": [],
-                "rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly": [
+                "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:linux"
                 ],
-                "rust_linux_x86_64__aarch64-unknown-linux-gnu__nightly": [
+                "rust_linux_x86_64__aarch64-unknown-linux-gnu__stable": [
                   "@platforms//cpu:aarch64",
                   "@platforms//os:linux"
                 ],

--- a/crates/starpls/src/document.rs
+++ b/crates/starpls/src/document.rs
@@ -363,7 +363,7 @@ impl DefaultFileLoader {
         Ok((file_id, contents))
     }
 
-    fn repo_for_path<'a>(&'a self, path: &'a Path) -> Option<&str> {
+    fn repo_for_path<'a>(&'a self, path: &'a Path) -> Option<&'a str> {
         match path.strip_prefix(&self.external_output_base) {
             Ok(stripped) => stripped
                 .components()

--- a/crates/starpls_bazel/src/label.rs
+++ b/crates/starpls_bazel/src/label.rs
@@ -24,7 +24,7 @@ pub struct Label<'a> {
 }
 
 impl<'a> Label<'a> {
-    pub fn parse(input: &'a str) -> ParseResult {
+    pub fn parse(input: &'a str) -> ParseResult<'a> {
         Parser {
             chars: input.chars(),
             pos: 0,

--- a/crates/starpls_hir/src/def/resolver.rs
+++ b/crates/starpls_hir/src/def/resolver.rs
@@ -97,7 +97,7 @@ impl<'a> Resolver<'a> {
     pub(crate) fn resolve_name(
         &'a self,
         name: &'a Name,
-    ) -> Option<(ExecutionScopeId, impl Iterator<Item = SymbolDef<'a>> + '_)> {
+    ) -> Option<(ExecutionScopeId, impl Iterator<Item = SymbolDef<'a>>)> {
         let mut defs = self
             .scopes_with_id()
             .filter_map(move |(scope_id, scope)| {

--- a/crates/starpls_hir/src/typeck.rs
+++ b/crates/starpls_hir/src/typeck.rs
@@ -926,10 +926,9 @@ impl Param {
                     HirDefParam::KwargsDict { .. }
                 )
             }
-            ParamInner::IntrinsicParam { parent, index } => matches!(
-                parent.params(db)[index],
-                IntrinsicFunctionParam::KwargsDict { .. }
-            ),
+            ParamInner::IntrinsicParam { parent, index } => {
+                matches!(parent.params(db)[index], IntrinsicFunctionParam::KwargsDict)
+            }
             ParamInner::BuiltinParam { parent, index } => matches!(
                 parent.params(db)[index],
                 BuiltinFunctionParam::KwargsDict { .. }
@@ -1460,7 +1459,10 @@ pub(crate) struct Rule {
 }
 
 impl Rule {
-    pub(crate) fn attrs<'a>(&'a self, db: &'a dyn Db) -> impl Iterator<Item = (&Name, &Attribute)> {
+    pub(crate) fn attrs<'a>(
+        &'a self,
+        db: &'a dyn Db,
+    ) -> impl Iterator<Item = (&'a Name, &'a Attribute)> {
         // This chaining is done to put the `name` attribute first.
         let common = common_attributes_query(db);
         let mut common_attrs = match self.kind {

--- a/crates/starpls_hir/src/typeck/infer.rs
+++ b/crates/starpls_hir/src/typeck/infer.rs
@@ -1662,7 +1662,7 @@ impl TyContext<'_> {
                         continue;
                     }
                 }
-                FlowNode::Unreachable { .. } => Ty::never(),
+                FlowNode::Unreachable => Ty::never(),
             };
 
             break Some(curr_node_ty);

--- a/crates/starpls_ide/src/completions.rs
+++ b/crates/starpls_ide/src/completions.rs
@@ -233,7 +233,7 @@ pub(crate) fn completions(
             for candidate in db.list_load_candidates(&value, file_id).ok()?? {
                 let start = TextSize::from(
                     value
-                        .rfind(&['/', ':', '@'])
+                        .rfind(['/', ':', '@'])
                         .map(|start| {
                             if candidate.replace_trailing_slash {
                                 start
@@ -569,7 +569,7 @@ impl CompletionContext {
 }
 
 fn strip_last_package_or_target(label: &str) -> &str {
-    if let Some(index) = label.rfind(&[':', '/']) {
+    if let Some(index) = label.rfind([':', '/']) {
         &label[..index + 1]
     } else {
         label

--- a/crates/starpls_ide/src/lib.rs
+++ b/crates/starpls_ide/src/lib.rs
@@ -470,6 +470,7 @@ pub trait FileLoader: Send + Sync + 'static {
 
 /// Simple implementation of [`FileLoader`] backed by a HashMap.
 /// Mainly used for tests.
+#[allow(dead_code)]
 #[derive(Default)]
 pub(crate) struct SimpleFileLoader(DashMap<String, LoadFileResult>);
 

--- a/crates/starpls_intern/src/lib.rs
+++ b/crates/starpls_intern/src/lib.rs
@@ -195,6 +195,7 @@ pub struct InternStorage<T: ?Sized> {
 }
 
 impl<T: ?Sized> InternStorage<T> {
+    #[allow(clippy::new_without_default)]
     pub const fn new() -> Self {
         Self {
             map: OnceLock::new(),

--- a/crates/starpls_parser/src/grammar/expressions.rs
+++ b/crates/starpls_parser/src/grammar/expressions.rs
@@ -41,10 +41,7 @@ pub(crate) fn binary_expr(
     tokens: &[SyntaxKind],
     next: fn(&mut Parser) -> Option<CompletedMarker>,
 ) -> Option<CompletedMarker> {
-    let mut m = match next(p) {
-        Some(m) => m,
-        None => return None,
-    };
+    let mut m = next(p)?;
 
     while tokens.contains(&p.current()) {
         let binary_marker = m.precede(p);
@@ -88,10 +85,7 @@ fn and_expr(p: &mut Parser) -> Option<CompletedMarker> {
 
 fn comparison_expr(p: &mut Parser) -> Option<CompletedMarker> {
     const COMP_TOKENS: &[SyntaxKind] = &[T![==], T![!=], T![<], T![>], T![<=], T![>=], T![in]];
-    let mut m = match bitwise_or_expr(p) {
-        Some(m) => m,
-        None => return None,
-    };
+    let mut m = bitwise_or_expr(p)?;
 
     loop {
         let is_not_in = if COMP_TOKENS.contains(&p.current()) {
@@ -150,10 +144,7 @@ fn unary_expr(p: &mut Parser) -> Option<CompletedMarker> {
 
 /// Parses a function call, subscript expression, or member access.
 pub(crate) fn primary_expr(p: &mut Parser) -> Option<CompletedMarker> {
-    let mut m = match operand_expr(p) {
-        Some(m) => m,
-        None => return None,
-    };
+    let mut m = operand_expr(p)?;
 
     loop {
         let next = match p.current() {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2023-12-06"
+channel = "1.87.0"

--- a/vendor/runfiles/src/lib.rs
+++ b/vendor/runfiles/src/lib.rs
@@ -303,7 +303,7 @@ pub fn find_runfiles_dir() -> Result<PathBuf> {
             while let Some(ancestor) = next {
                 if ancestor
                     .file_name()
-                    .map_or(false, |f| f.to_string_lossy().ends_with(".runfiles"))
+                    .is_some_and(|f| f.to_string_lossy().ends_with(".runfiles"))
                 {
                     return Ok(ancestor.to_path_buf());
                 }


### PR DESCRIPTION
Trait upcasting was stabilized in Rust 1.86: https://github.com/rust-lang/rust/pull/134367

This was the only reason we were using nightly Rust, so we can go back to stable Rust now!