### PR TITLE
feat: implement textDocument/formatting

### DIFF
--- a/crates/starpls/src/commands/server.rs
+++ b/crates/starpls/src/commands/server.rs
@@ -62,6 +62,7 @@ impl ServerCommand {
             }),
             declaration_provider: Some(DeclarationCapability::Simple(true)),
             definition_provider: Some(OneOf::Left(true)),
+            document_formatting_provider: Some(OneOf::Left(true)),
             document_symbol_provider: Some(OneOf::Left(true)),
             hover_provider: Some(HoverProviderCapability::Simple(true)),
             references_provider: Some(OneOf::Left(true)),

--- a/crates/starpls/src/commands/server.rs
+++ b/crates/starpls/src/commands/server.rs
@@ -24,6 +24,10 @@ pub(crate) struct ServerCommand {
     #[clap(long = "bazel_path")]
     pub(crate) bazel_path: Option<String>,
 
+    /// Enable document formatting support via buildifier.
+    #[clap(long = "enable_formatting", default_value_t = false)]
+    pub(crate) enable_formatting: bool,
+
     /// Enable completions for labels for targets in the current workspace.
     #[clap(
         long = "experimental_enable_label_completions",
@@ -62,7 +66,7 @@ impl ServerCommand {
             }),
             declaration_provider: Some(DeclarationCapability::Simple(true)),
             definition_provider: Some(OneOf::Left(true)),
-            document_formatting_provider: Some(OneOf::Left(true)),
+            document_formatting_provider: self.enable_formatting.then_some(OneOf::Left(true)),
             document_symbol_provider: Some(OneOf::Left(true)),
             hover_provider: Some(HoverProviderCapability::Simple(true)),
             references_provider: Some(OneOf::Left(true)),

--- a/crates/starpls/src/config.rs
+++ b/crates/starpls/src/config.rs
@@ -1,9 +1,24 @@
 use lsp_types::ClientCapabilities;
+use serde::Deserialize;
+use serde_json::Value;
 
 use crate::commands::server::ServerCommand;
 
+#[derive(Deserialize, Default)]
+#[serde(default)]
+pub(crate) struct BuildifierConfig {
+    pub(crate) path: Option<String>,
+    pub(crate) args: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct InitializationOptions {
+    buildifier: Option<BuildifierConfig>,
+}
+
 #[derive(Default)]
 pub(crate) struct ServerConfig {
+    pub(crate) buildifier: Option<BuildifierConfig>,
     pub(crate) args: ServerCommand,
     pub(crate) caps: ClientCapabilities,
 }
@@ -15,6 +30,13 @@ macro_rules! try_or_default {
 }
 
 impl ServerConfig {
+    pub(crate) fn from_json(value: Value) -> Self {
+        let mut config = ServerConfig::default();
+        if let Ok(opts) = serde_json::from_value::<InitializationOptions>(value) {
+            config.buildifier = opts.buildifier;
+        }
+        config
+    }
     pub(crate) fn has_text_document_definition_link_support(&self) -> bool {
         try_or_default!(self.caps.text_document.as_ref()?.definition?.link_support)
     }

--- a/crates/starpls/src/event_loop.rs
+++ b/crates/starpls/src/event_loop.rs
@@ -77,10 +77,10 @@ pub fn process_connection(
     initialize_params: InitializeParams,
 ) -> anyhow::Result<()> {
     debug!("initializing state and starting event loop");
-    let config = ServerConfig {
-        args,
-        caps: initialize_params.capabilities,
-    };
+    let mut config =
+        ServerConfig::from_json(initialize_params.initialization_options.unwrap_or_default());
+    config.args = args;
+    config.caps = initialize_params.capabilities;
     let server = Server::new(connection, config)?;
     server.run()
 }
@@ -218,6 +218,7 @@ impl Server {
             .on::<lsp_types::request::HoverRequest>(requests::hover)
             .on::<lsp_types::request::References>(requests::find_references)
             .on::<lsp_types::request::SignatureHelpRequest>(requests::signature_help)
+            .on::<lsp_types::request::Formatting>(requests::formatting)
             .finish();
     }
 

--- a/crates/starpls/src/handlers/requests.rs
+++ b/crates/starpls/src/handlers/requests.rs
@@ -293,6 +293,10 @@ pub(crate) fn formatting(
     snapshot: &ServerSnapshot,
     params: lsp_types::DocumentFormattingParams,
 ) -> anyhow::Result<Option<Vec<lsp_types::TextEdit>>> {
+    if !snapshot.config.args.enable_formatting {
+        return Ok(None);
+    }
+
     let path = path_buf_from_url(&params.text_document.uri)?;
     let file_id = try_opt!(snapshot.document_manager.read().lookup_by_path_buf(&path));
     let line_index = try_opt!(snapshot.analysis_snapshot.line_index(file_id)?);

--- a/crates/starpls_ide/src/lib.rs
+++ b/crates/starpls_ide/src/lib.rs
@@ -398,6 +398,10 @@ impl AnalysisSnapshot {
         self.query(|db| signature_help::signature_help(db, pos))
     }
 
+    pub fn file_contents(&self, file_id: FileId) -> Cancellable<Option<String>> {
+        self.query(|db| db.get_file(file_id).map(|file| file.contents(db).clone()))
+    }
+
     /// Helper method to handle Salsa cancellations.
     fn query<'a, F, T>(&'a self, f: F) -> Cancellable<T>
     where


### PR DESCRIPTION
This is done by spawning a `buildifier` process.

Buildifier can be configured in the initialization options:
```json
{
    "buildifier": {
        "path": "...",
        "args": ["...", "...."]
     }
}
```

Closes #267

PS: note that this was done at 99% by Gemini Pro 2.5