### PR TITLE
fix: add development version to list supporting bzlmod

### DIFF
--- a/crates/starpls/src/bazel.rs
+++ b/crates/starpls/src/bazel.rs
@@ -31,7 +31,7 @@ impl BazelContext {
             // bzlmod is enabled by default for Bazel versions 7 and later.
             // TODO(withered-magic): Just hardcoding this for now since I'm lazy to parse the actual versions.
             // This should last us pretty long since Bazel 9 isn't anywhere on the horizon.
-            let bzlmod_enabled_by_default = ["release 7", "release 8", "release 9"]
+            let bzlmod_enabled_by_default = ["development", "release 7", "release 8", "release 9"]
                 .iter()
                 .any(|release| info.release.starts_with(release));
 


### PR DESCRIPTION
If you use a development version of Bazel, the current logic doesn't identify it as supporting bzlmod. You can reproduce by pointing bazelisk at a sha instead of a release version:

```diff
diff --git a/.bazeliskrc b/.bazeliskrc
index 330b936..1df2767 100644
--- a/.bazeliskrc
+++ b/.bazeliskrc
@@ -1 +1 @@
-USE_BAZEL_VERSION=8.2.1
+USE_BAZEL_VERSION=2f67489da598c37d45c9b2b8601740d6e5a34851
```

And then checking the `info`:

```bash
$ bazelisk info
...
release: development version
```

This PR assumes that any development versions support bzlmod since it has been default for a while now, so it seems ~mostly safe.