### PR TITLE
feat: add buildozer query

### DIFF
--- a/crates/starpls/src/commands/server.rs
+++ b/crates/starpls/src/commands/server.rs
@@ -42,6 +42,10 @@ pub(crate) struct ServerCommand {
     #[clap(long = "analysis_debounce_interval", default_value_t = 250)]
     pub(crate) analysis_debounce_interval: u64,
 
+    /// Whether to use buildozer to query for targets.
+    #[clap(long = "use_buildozer", default_value_t = false)]
+    pub(crate) use_buildozer: bool,
+
     #[command(flatten)]
     pub(crate) inference_options: InferenceOptions,
 }

--- a/crates/starpls/src/server.rs
+++ b/crates/starpls/src/server.rs
@@ -90,7 +90,8 @@ impl Server {
 
         // Determine Bazel configuration.
         let mut has_bazel_init_err = false;
-        let bazel_client = Arc::new(BazelCLI::new(&bazel_path));
+        let bazel_client =
+            Arc::new(BazelCLI::new(&bazel_path).with_buildozer(config.args.use_buildozer));
         let bazel_cx = match BazelContext::new(&*bazel_client) {
             Ok(cx) => cx,
             Err(err) => {


### PR DESCRIPTION
Bazel query can be pretty CPU intensive and take a while for large repos, so providing `--use_buildozer` as a faster alternative.
