### PR TITLE
Follow symlinks to make ctrl+click work with vendored rules

### DIFF
--- a/crates/starpls/src/document.rs
+++ b/crates/starpls/src/document.rs
@@ -317,6 +317,10 @@ impl DefaultFileLoader {
         }
         .join(label.target());
 
+        // Follow symlinks, so that ctrl+click works correctly with vendored rules.
+        // Without this, ctrl+click opens an editor with path in ~/.cache/bazel, which path contains a symlink to the vendored rule.
+        let resolved_path = resolved_path.canonicalize().unwrap_or(resolved_path);
+
         Ok(Some(ResolvedLabel {
             resolved_path,
             canonical_repo: canonical_repo_res,


### PR DESCRIPTION
When using [vendored rules](https://bazel.build/external/vendor), when I ctrl+click on e.g. `rust_binary`, it opens an editor whose path is `~/.cache/bazel/_bazel_<username>/<hash>/external/rules_rust+/rust/defs.bzl`.  In that path, `rules_rust+` is a symlink to the vendored `rules_rust+`, so by following the symlink, ctrl+click opens an editor with path `vendor/bazel/rules_rust+/rust/defs/bzl`, which is more readable and less confusing.