### PR TITLE
Gate remote caching flags on whether the API key exists

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -21,6 +21,8 @@ build --incompatible_strict_action_env
 
 test --test_output=errors
 
+build --experimental_convenience_symlinks=normal
+
 build:linux --sandbox_add_mount_pair=/tmp
 build:linux --incompatible_enable_cc_toolchain_resolution
 build:linux --action_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,8 +31,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Prepare for build
         run: |
-          echo 'import %workspace%/bazel/remote-cache.bazelrc' >>.bazelrc
-          echo "build --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY" >>.bazelrc
+          if [[ -n "$BUILDBUDDY_API_KEY" ]]; then
+            echo 'import %workspace%/bazel/remote-cache.bazelrc' >>.bazelrc
+            echo "build --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY" >>.bazelrc
+          fi
           echo "startup --output_user_root=C:/b" >>.bazelrc
           echo "startup --windows_enable_symlinks" >>.bazelrc
           mkdir -p editors/code/dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Prepare for build
         run: |
-          echo 'import %workspace%/bazel/remote-cache.bazelrc' >>.bazelrc
-          echo "build --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY" >>.bazelrc
+          if [[ -n "$BUILDBUDDY_API_KEY" ]]; then
+            echo 'import %workspace%/bazel/remote-cache.bazelrc' >>.bazelrc
+            echo "build --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY" >>.bazelrc
+          fi
           echo "startup --output_user_root=C:/b" >>.bazelrc
           echo "startup --windows_enable_symlinks" >>.bazelrc
           mkdir -p editors/code/dist

--- a/bazel/remote-cache.bazelrc
+++ b/bazel/remote-cache.bazelrc
@@ -1,5 +1,3 @@
-build --experimental_convenience_symlinks=normal
-
 build --bes_results_url=https://starpls.buildbuddy.io/invocation/
 build --bes_backend=grpcs://starpls.buildbuddy.io
 build --remote_cache=grpcs://starpls.buildbuddy.io

--- a/bazel/setup-ci.sh
+++ b/bazel/setup-ci.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
-echo 'import %workspace%/bazel/remote-cache.bazelrc' >>.bazelrc
-echo "build --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY" >>.bazelrc
+if [[ -n "$BUILDBUDDY_API_KEY" ]]; then
+    echo 'import %workspace%/bazel/remote-cache.bazelrc' >>.bazelrc
+    echo "build --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY" >>.bazelrc
+fi


### PR DESCRIPTION
This fixes CI running from forks
