### PR TITLE
Fix: Enable bzlmod by default for Bazel 7 onwards

### DIFF
--- a/crates/starpls/src/bazel.rs
+++ b/crates/starpls/src/bazel.rs
@@ -29,11 +29,8 @@ impl BazelContext {
         // Check if bzlmod is enabled for the current workspace.
         let bzlmod_enabled = {
             // bzlmod is enabled by default for Bazel versions 7 and later.
-            // TODO(withered-magic): Just hardcoding this for now since I'm lazy to parse the actual versions.
-            // This should last us pretty long since Bazel 9 isn't anywhere on the horizon.
-            let bzlmod_enabled_by_default = ["development", "release 7", "release 8", "release 9"]
-                .iter()
-                .any(|release| info.release.starts_with(release));
+            // Bazel 6 is the only remaining supported version that we do not enable bzlmod by default for.
+            let bzlmod_enabled_by_default = !info.release.starts_with("release 6");
 
             if bzlmod_enabled_by_default {
                 info!("Bazel 7 or later detected");


### PR DESCRIPTION
Right now we have a hardcoded list of versions that needs to be updated, currently Bazel 10 prerelease versions are not enabling bzlmod. Rather than add another value to the list, we only need to disable bzlmod by default for Bazel 6, and now this is permanently fixed.
