### PR TITLE
Fix escape sequences in triple quotes not resetting the closing streak

### DIFF
--- a/crates/starpls_lexer/src/lib.rs
+++ b/crates/starpls_lexer/src/lib.rs
@@ -812,10 +812,12 @@ impl Cursor<'_> {
                 {
                     // Bump again to skip the escaped character.
                     self.bump();
+                    closing_streak = 0;
                 }
                 '\\' if self.first() == '\r' && self.second() == '\n' => {
                     self.bump();
                     self.bump();
+                    closing_streak = 0;
                 }
                 _ => {
                     closing_streak = 0;

--- a/crates/starpls_lexer/src/tests.rs
+++ b/crates/starpls_lexer/src/tests.rs
@@ -485,6 +485,9 @@ x = '''a\r\nb'''
 x = """a\r\nb"""
 x = '''a\n\rb'''
 x = """a\n\rb"""
+x = """
+"\\""
+"""
 x = r'a\\\nb'
 x = r"a\\\nb"
 x = r'a\\\rb'
@@ -637,6 +640,12 @@ x = r"a\\\r\nb"
             Token { kind: Eq, len: 1 }
             Token { kind: Whitespace, len: 1 }
             Token { kind: Literal { kind: Str { terminated: true, triple_quoted: true } }, len: 12 }
+            Token { kind: Newline, len: 1 }
+            Token { kind: Ident, len: 1 }
+            Token { kind: Whitespace, len: 1 }
+            Token { kind: Eq, len: 1 }
+            Token { kind: Whitespace, len: 1 }
+            Token { kind: Literal { kind: Str { terminated: true, triple_quoted: true } }, len: 13 }
             Token { kind: Newline, len: 1 }
             Token { kind: Ident, len: 1 }
             Token { kind: Whitespace, len: 1 }


### PR DESCRIPTION
While lexing a triple-quoted string, hitting an escape sequence would not reset the three-quote count. So something like `"\\"\\"` would still count as 3 quotes, even though it should get reset in the middle.

Fixes #422
